### PR TITLE
bump composer php version

### DIFF
--- a/variables.env
+++ b/variables.env
@@ -7,7 +7,7 @@ ELASTICSEARCH_IMAGE_NAME=elasticsearch
 WIKIBASE_BUNDLE_IMAGE_NAME=wikibase-bundle
 QUICKSTATEMENTS_IMAGE_NAME=quickstatements
 
-COMPOSER_IMAGE_NAME=docker-registry.wikimedia.org/releng/composer-php72
+COMPOSER_IMAGE_NAME=docker-registry.wikimedia.org/releng/composer-php73
 COMPOSER_IMAGE_VERSION=latest
 
 # Releasing tarballs


### PR DESCRIPTION
Seems we need 7.3 to build REL1_35

https://github.com/wmde/wikibase-release-pipeline/actions/runs/580831354