### PR TITLE
Fix error on reporter

### DIFF
--- a/test/reporter/report.js
+++ b/test/reporter/report.js
@@ -18,7 +18,10 @@ if (fs.existsSync(filePath)) {
 
         resultObject.fail.forEach(test => {
             const error = extractModuleLineAndColumn(test.error.stack);
-            const filePath = error.file.replace('/usr/src/app/', 'Docker/test/selenium/');
+            let filePath = '';
+            if( error.file ) {
+                filePath = error.file.replace('/usr/src/app/', 'Docker/test/selenium/');
+            }
             const message = test.fullTitle + ": " + test.error.message;
             
             issueCommand('error', {


### PR DESCRIPTION
Sometimes there is no file on these errors and then the reporter crashes
instead, which is less than ideal.