### PR TITLE
Move interwiki link creation to test

### DIFF
--- a/Docker/test/selenium/data/interwiki-link.sql
+++ b/Docker/test/selenium/data/interwiki-link.sql
@@ -1,0 +1,1 @@
+INSERT INTO interwiki (iw_prefix, iw_url, iw_api, iw_wikiid, iw_local, iw_trans) VALUES ("<WIKI_ID>", "<HOSTNAME>/wiki/\$1", "<HOSTNAME>/w/api.php", "", "1", "0")

--- a/Docker/test/selenium/specs/repo-client/item.js
+++ b/Docker/test/selenium/specs/repo-client/item.js
@@ -23,6 +23,30 @@ describe( 'Item', function () {
 		defaultFunctions();
 	} );
 
+	it( 'Should be able to insert interwiki links', function () {
+
+		const repoLink = fs.readFileSync( 'data/interwiki-link.sql', 'utf8' )
+			.replace( /<WIKI_ID>/g, 'client_wiki' )
+			.replace( /<HOSTNAME>/g, process.env.MW_CLIENT_SERVER );
+		const repoResult = browser.dbQuery( repoLink );
+
+		const config = {
+			user: process.env.DB_USER,
+			pass: process.env.DB_PASS,
+			database: 'client_wiki'
+		};
+		const clientLink = fs.readFileSync( 'data/interwiki-link.sql', 'utf8' )
+			.replace( /<WIKI_ID>/g, 'my_wiki' )
+			.replace( /<HOSTNAME>/g, process.env.MW_SERVER );
+
+		const clientResult = browser.dbQuery( clientLink, config );
+
+		// should not return any errors
+		assert( repoResult === '' );
+		assert( clientResult === '' );
+
+	} );
+
 	it( 'Special:NewItem should not be accessible on client', function () {
 
 		browser.url( process.env.MW_CLIENT_SERVER + '/wiki/Special:NewItem?uselang=qqx' );

--- a/test/config/client/wikibase/extra-install-client.sh
+++ b/test/config/client/wikibase/extra-install-client.sh
@@ -6,10 +6,5 @@ set -ex
 # client
 php /var/www/html/maintenance/addSite.php --conf LocalSettings.php --wiki client_wiki  --pagepath=http://wikibase.svc/wiki/\$1  --filepath=http://wikibase.svc/w/\$1 --language en --interwiki-id my_wiki my_wiki mywikigroup
 
-# Add interwiki links
-# insert interwiki link to repo on client 
-echo "INSERT INTO \`interwiki\` (\`iw_prefix\`, \`iw_url\`, \`iw_api\`, \`iw_wikiid\`, \`iw_local\`, \`iw_trans\`) VALUES ('my_wiki', 'http://wikibase.svc/wiki/\$1', 'http://wikibase.svc/w/api.php', '', '1', '0')" >> /tmp/client.sql
-php /var/www/html/maintenance/patchSql.php --wiki=client_wiki /tmp/client.sql
-
 # startup jobs
 php /var/www/html/maintenance/runJobs.php --wiki client_wiki --wait &

--- a/test/config/client/wikibase/extra-install-repo.sh
+++ b/test/config/client/wikibase/extra-install-repo.sh
@@ -6,11 +6,6 @@ set -ex
 # repo
 php /var/www/html/maintenance/addSite.php --wiki my_wiki --conf LocalSettings.php  --pagepath=http://wikibase-client.svc/wiki/\$1  --filepath=http://wikibase-client.svc/w/\$1 --language en --interwiki-id client_wiki client_wiki mywikigroup
 
-# Add interwiki links
-# insert interwiki link to client on repo
-echo "INSERT INTO \`interwiki\` (\`iw_prefix\`, \`iw_url\`, \`iw_api\`, \`iw_wikiid\`, \`iw_local\`, \`iw_trans\`) VALUES ('client_wiki', 'http://wikibase-client.svc/wiki/\$1', 'http://wikibase-client.svc/w/api.php', '', '1', '0')" >> /tmp/repo.sql
-php /var/www/html/maintenance/patchSql.php --wiki=my_wiki /tmp/repo.sql
-
 ## run dispatcher
 php /var/www/html/extensions/Wikibase/repo/maintenance/dispatchChanges.php --wiki my_wiki --idle-delay 5 --dispatch-interval 1 --client client_wiki &
 


### PR DESCRIPTION
While chasing down T277362 yesterday I was trying to debug this locally
and ended up with these changes that moves the interwiki link creation
from the extra-install scripts to the actual test in the hopes to
understand why things were failing. It didn't but i think this change is
preferable than having things hidden in extra-install.