### PR TITLE
Isolate elasticsearch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [ repo, fedprops, repo-client, quickstatements, pingback, confirm-edit ]
+        suite: [ repo, fedprops, repo-client, quickstatements, pingback, confirm-edit, elasticsearch ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Docker/test/selenium/package.json
+++ b/Docker/test/selenium/package.json
@@ -28,6 +28,7 @@
 		"ie 11"
 	],
 	"scripts": {
+		"test:elasticsearch": "wdio wdio.conf.js --spec specs/elasticsearch/*",
 		"test:repo": "wdio wdio.conf.js --spec specs/repo/*",
 		"test:repo-client": "wdio wdio.conf.js --spec specs/repo-client/*",
 		"test:fedprops": "wdio wdio.conf.js --spec specs/federated-properties/*",

--- a/Docker/test/selenium/specs/elasticsearch/elasticsearch.js
+++ b/Docker/test/selenium/specs/elasticsearch/elasticsearch.js
@@ -62,7 +62,7 @@ describe( 'ElasticSearch', function () {
 		// run jobs detached
 		browser.dockerExecute(
 			process.env.DOCKER_WIKIBASE_REPO_NAME,
-			'php /var/www/html/maintenance/runJobs.php --wiki my_wiki --wait --maxjobs 20',
+			"bash -c 'php /var/www/html/maintenance/runJobs.php --wiki my_wiki --wait --maxjobs 2 > /var/log/runJobs.log'",
 			'--detach'
 		);
 
@@ -70,6 +70,14 @@ describe( 'ElasticSearch', function () {
 			process.env.DOCKER_WIKIBASE_REPO_NAME,
 			'php extensions/CirrusSearch/maintenance/ForceSearchIndex.php --queue --maxJobs 10000 --pauseForJobs 1000 --skipLinks --indexOnSkip'
 		);
+
+		const logResult = browser.dockerExecute(
+			process.env.DOCKER_WIKIBASE_REPO_NAME,
+			'cat /var/log/runJobs.log'
+		);
+
+		assert( logResult.includes( 'cirrusSearchMassIndex Special: pageDBKeys=["Main_Page","Item:Q1"]' ) === true );
+		assert( logResult.includes( 'cirrusSearchElasticaWrite' ) === true );
 
 		// should have queued some stuff
 		assert( resultCommand.includes( 'Queued a total of' ) === true );

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test-all:
 	bash test/test_suite.sh quickstatements
 	bash test/test_suite.sh pingback
 	bash test/test_suite.sh confirm-edit
+	bash test/test_suite.sh elasticsearch
 
 mediawiki:
 	bash update_cache.sh core skins

--- a/test/suite-config/elasticsearch/LocalSettings.php
+++ b/test/suite-config/elasticsearch/LocalSettings.php
@@ -1,0 +1,7 @@
+<?php
+error_reporting( -1 );
+ini_set( 'display_errors', 1 );
+$wgShowExceptionDetails = true;
+$wgShowSQLErrors = true;
+$wgDebugDumpSql  = true;
+$wgShowDBErrorBacktrace = true;


### PR DESCRIPTION
Seems running this test with the repo suite is not ideal as there is an
uncertainty of when this test will get executed and how many jobs will
be required etc.

This change moves elasticsearch testing to it's own suite. Some additional assertions now that we know the exact number of jobs required.