### PR TITLE
Turn off uploading of every build.

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -58,12 +59,6 @@ jobs:
         with:
           image_name: ${{ env.MEDIAWIKI_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.MEDIAWIKI_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
         
   build_wikibase:
     runs-on: ubuntu-latest
@@ -121,6 +116,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -132,12 +128,6 @@ jobs:
         with:
           image_name: ${{ env.WIKIBASE_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.WIKIBASE_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
       - name: Archive base docker production artifact
         uses: actions/upload-artifact@v2
@@ -189,6 +179,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -200,12 +191,6 @@ jobs:
         with:
           image_name: ${{ env.WIKIBASE_BUNDLE_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.WIKIBASE_BUNDLE_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
       - name: Archive bundle docker production artifacts
         uses: actions/upload-artifact@v2
@@ -240,6 +225,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -251,12 +237,6 @@ jobs:
         with:
           image_name: ${{ env.QUICKSTATEMENTS_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.QUICKSTATEMENTS_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
       - name: Archive docker production artifacts
         uses: actions/upload-artifact@v2
@@ -292,6 +272,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -303,12 +284,6 @@ jobs:
         with:
           image_name: ${{ env.WDQS_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.WDQS_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
       - name: Archive docker production artifacts
         uses: actions/upload-artifact@v2
@@ -335,6 +310,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -346,12 +322,6 @@ jobs:
         with:
           image_name: ${{ env.WDQS_PROXY_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.WDQS_PROXY_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
       - name: Archive docker production artifacts
         uses: actions/upload-artifact@v2
@@ -407,6 +377,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -418,11 +389,6 @@ jobs:
         with:
           image_name: ${{ env.WDQS_FRONTEND_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.WDQS_FRONTEND_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
   build_elasticsearch:
     runs-on: ubuntu-latest
@@ -449,6 +415,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -460,12 +427,6 @@ jobs:
         with:
           image_name: ${{ env.ELASTICSEARCH_IMAGE_NAME }}
           tag: ${{ env.WMDE_RELEASE_VERSION }}
-
-      - name: Store workflow id image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ env.ELASTICSEARCH_IMAGE_NAME }}
-          tag: ${{ github.run_id }}
 
   test_wikibase:
     strategy:


### PR DESCRIPTION
Due to us hitting the abuse limit when many workflow runs are uploading
in a short time frame.