### PR TITLE
Update the link to point to new dumpRdf.php documentation

### DIFF
--- a/Docker/build/WDQS/README.md
+++ b/Docker/build/WDQS/README.md
@@ -13,9 +13,7 @@ If all changes are still in [RecentChanges] then simply removing `/wdqs/data` an
 
 If you can not use [RecentChanges] then you will need to reload from an RDF dump:
 
- - Make an RDF dump from your Wikibase repository using the [dumpRdf.php](https://github.com/wikimedia/mediawiki-extensions-Wikibase/blob/master/repo/maintenance/dumpRdf.php) maintenance script.
-
-
+ - [Make an RDF dump from your Wikibase repository using the dumpRdf.php maintenance script.](https://doc.wikimedia.org/Wikibase/master/php/md_docs_topics_rdf-binding.html)
  - [Load the RDF dump into the query service](https://github.com/wikimedia/wikidata-query-rdf/blob/master/docs/getting-started.md#load-the-dump)
 
 ### Environment variables


### PR DESCRIPTION
This needs to get merged and publish before this would make any sense. https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/681655