### PR TITLE
T280932 fix broken search

### DIFF
--- a/Docker/build/WikibaseBundle/LocalSettings.d/Elasticsearch.php
+++ b/Docker/build/WikibaseBundle/LocalSettings.d/Elasticsearch.php
@@ -5,7 +5,9 @@ wfLoadExtension( 'Elastica' );
 wfLoadExtension( 'CirrusSearch' );
 wfLoadExtension( 'WikibaseCirrusSearch' );
 
-$wgCirrusSearchServers = getenv('MW_ELASTIC_HOST') !== false ? [ $_ENV['MW_ELASTIC_HOST'] ] : [];
-$wgSearchType = 'CirrusSearch';
-$wgCirrusSearchExtraIndexSettings['index.mapping.total_fields.limit'] = 5000;
-$wgWBCSUseCirrus = true;
+if ( getenv('MW_ELASTIC_HOST') !== false ) {
+    $wgCirrusSearchServers = [ $_ENV['MW_ELASTIC_HOST'] ];
+    $wgSearchType = 'CirrusSearch';
+    $wgCirrusSearchExtraIndexSettings['index.mapping.total_fields.limit'] = 5000;
+    $wgWBCSUseCirrus = true;
+}

--- a/Docker/test/selenium/specs/repo/search.js
+++ b/Docker/test/selenium/specs/repo/search.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require( 'assert' );
+const WikibaseApi = require( 'wdio-wikibase/wikibase.api' );
+const defaultFunctions = require( '../../helpers/default-functions' );
+
+describe( 'Search', function () {
+
+	before( function () {
+		defaultFunctions();
+	} );
+
+	it( 'Should be able to create an item and search for it', function () {
+
+		const itemLabel = 'something';
+		browser.call(
+			() => WikibaseApi.createItem( itemLabel, {} )
+		);
+
+		const result = browser.makeRequest(
+			process.env.MW_SERVER +
+			'/w/api.php?action=wbsearchentities&search=' +
+			itemLabel +
+			'&format=json&errorformat=plaintext&language=en&uselang=en&type=item'
+		);
+		assert( result.data.search[ 0 ].label === itemLabel );
+
+	} );
+} );

--- a/example/README.md
+++ b/example/README.md
@@ -39,7 +39,15 @@ In the volumes section of the wikibase service there is one commented line that 
 
 Looking inside extra-install.sh it executes two scripts that sets up an OAuth consumer for quickstatements and creates indicies for elasticsearch.
 
-### 2. Run with the extra configuration
+### 2. Uncomment MW_ELASTIC_HOST and MW_ELASTIC_PORT in `docker-compose.yml`
+
+To configure wikibase to use elasticsearch we need to uncomment the following two lines in the example docker-compose.yml file
+```
+      - MW_ELASTIC_HOST=elasticsearch.svc
+      - MW_ELASTIC_PORT=9200
+``` 
+
+### 3. Run with the extra configuration
 
 ```
 docker-compose -f docker-compose.yml -f docker-compose.extra.yml up

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       - DB_USER=${DB_USER}
       - DB_PASS=${DB_PASS}
       - DB_NAME=${DB_NAME}
-      - MW_ELASTIC_HOST=elasticsearch.svc
-      - MW_ELASTIC_PORT=9200
+      #- MW_ELASTIC_HOST=elasticsearch.svc
+      #- MW_ELASTIC_PORT=9200
       - WIKIBASE_HOST
       - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://${QUICKSTATEMENTS_HOST}:${QUICKSTATEMENTS_PORT}
       - WIKIBASE_PINGBACK

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -29,8 +29,6 @@ services:
       - DB_USER=wikiuser
       - DB_PASS=sqlpass
       - DB_NAME=my_wiki
-      - MW_ELASTIC_HOST=elasticsearch.svc
-      - MW_ELASTIC_PORT=9200
       - MW_WG_ENABLE_UPLOADS=true
   mysql:
     image: ${DATABASE_IMAGE_NAME}


### PR DESCRIPTION
When running bundle without MW_ELASTIC_HOST we should still be able to search