### PR TITLE
QuickStatements: Use public API url

### DIFF
--- a/Docker/build/QuickStatements/config.json
+++ b/Docker/build/QuickStatements/config.json
@@ -12,8 +12,8 @@
 				"mwOAuthUrl":"${WIKIBASE_SCHEME_AND_HOST}/w/index.php?title=Special:OAuth" ,
 				"mwOAuthIW":"mw"
 			} ,
-			"server" : "${WB_PUBLIC_HOST_AND_PORT}" ,
-			"api" : "${WIKIBASE_SCHEME_AND_HOST}/w/api.php" ,
+			"server" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}" ,
+			"api" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/w/api.php" ,
 			"pageBase" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/wiki/" ,
 			"toolBase" : "${QS_PUBLIC_SCHEME_HOST_AND_PORT}/" ,
 			"types" : {


### PR DESCRIPTION
This URL is used for both internal fetches by the QuickStatements backend and for AJAX-fetches in the frontend.
Also properly set "server" (`WB_PUBLIC_HOST_AND_PORT` is not defined anywhere).