### PR TITLE
add cron for every six hours for .env

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -12,7 +12,8 @@ on:
   push:
 
 env:
-  env_file: ${{ github.event.inputs.env_file ||  github.event.schedule=='0 */6 * * *' && '.env' || 'versions/wmde1.env' }}
+  env_file: ${{ github.event.inputs.env_file || 'versions/wmde1.env' }}
+
 jobs:
   build_mediawiki:
     runs-on: ubuntu-latest

--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -1,6 +1,8 @@
 name: Build and test Wikibase and friends
 
 on:
+  schedule:
+    - cron:  '0 */6 * * *'
   workflow_dispatch:
     inputs:
       env_file:
@@ -10,8 +12,7 @@ on:
   push:
 
 env:
-  env_file: ${{ github.event.inputs.env_file || 'versions/wmde1.env' }}
-
+  env_file: ${{ github.event.inputs.env_file ||  github.event.schedule=='0 */6 * * *' && '.env' || 'versions/wmde1.env' }}
 jobs:
   build_mediawiki:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Will have to be merged to main to start cronning.

- Would currently not build master since the pipeline is set to build the upcoming release.