### PR TITLE
Optimize image size

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,15 @@ on:
   push:
 
 jobs:
+  lint_dockerfiles:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # TODO: Replace with the official hadolint/hadolint-action once change is upstreamed
+      - uses: itamargiv/hadolint-action@v1.5.1-h
+        with:
+          recursive: true
+
   lint_shell_scripts:
     runs-on: ubuntu-latest
     steps:

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,0 +1,20 @@
+ignored:
+  - DL3007
+  - DL3008
+  - DL3009
+  - DL3010
+  - DL3013
+  - DL3015
+  - DL3018
+  - DL3019
+  - DL3020
+  - DL3025
+  - DL3042
+  - DL3045
+  - SC2034
+  - SC2086
+
+override:
+  # Raise severity from info
+  warning:
+    - DL3059

--- a/Docker/build/Mediawiki/Dockerfile
+++ b/Docker/build/Mediawiki/Dockerfile
@@ -56,8 +56,8 @@ ENV MEDIAWIKI_VERSION ${MEDIAWIKI_VERSION}
 
 # MediaWiki setup
 COPY mediawiki.tar.gz /tmp/mediawiki.tar.gz
-RUN tar -x --strip-components=1 -f /tmp/mediawiki.tar.gz;
-RUN rm /tmp/mediawiki.tar.gz;
-RUN chown -R www-data:www-data extensions skins cache images;
+RUN tar -x --strip-components=1 -f /tmp/mediawiki.tar.gz && \
+	rm /tmp/mediawiki.tar.gz && \
+	chown -R www-data:www-data extensions skins cache images;
 
 CMD ["apache2-foreground"]

--- a/Docker/build/QuickStatements/Dockerfile
+++ b/Docker/build/QuickStatements/Dockerfile
@@ -16,10 +16,9 @@ FROM php:7.2-apache
 # Install envsubst
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* jq=1.5* libicu-dev=63* && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN docker-php-ext-configure intl \
-&& docker-php-ext-install intl
+    rm -rf /var/lib/apt/lists/* && \
+    docker-php-ext-configure intl && \
+    docker-php-ext-install intl
 
 COPY --from=fetcher /quickstatements /var/www/html/quickstatements
 COPY --from=composer --chown=root:root /quickstatements/vendor /var/www/html/quickstatements/vendor
@@ -32,8 +31,8 @@ COPY oauth.ini /templates/oauth.ini
 COPY php.ini /templates/php.ini
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/quickstatements/public_html
-RUN sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf
-RUN sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+RUN sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf && \
+    sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 ENV MW_SITE_NAME=wikibase-docker\
     MW_SITE_LANG=en\

--- a/Docker/build/WDQS/Dockerfile
+++ b/Docker/build/WDQS/Dockerfile
@@ -16,9 +16,8 @@ FROM openjdk:8-jdk-alpine
 # Install gettext for envsubst command, (it needs libintl package)
 # Install curl for the loadData.sh wdqs script (if someone needs it)
 RUN set -x ; \
-    apk --no-cache add bash=\<4.5.0 gettext=\<0.19.8.2 libintl=\<0.19.8.2 curl=\<7.64.999 su-exec=\~0.2
-
-RUN addgroup -g 66 -S blazegraph && adduser -S -G blazegraph -u 666 -s /bin/bash blazegraph
+    apk --no-cache add bash=\<4.5.0 gettext=\<0.19.8.2 libintl=\<0.19.8.2 curl=\<7.64.999 su-exec=\~0.2 && \
+    addgroup -g 66 -S blazegraph && adduser -S -G blazegraph -u 666 -s /bin/bash blazegraph
 
 COPY --from=fetcher --chown=blazegraph:blazegraph /wdqs-service /wdqs
 

--- a/Docker/build/Wikibase/Dockerfile
+++ b/Docker/build/Wikibase/Dockerfile
@@ -5,9 +5,9 @@ FROM ubuntu:xenial as unpacker
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends unzip=6.* jq=1.* curl=7.* ca-certificates=201* && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mkdir artifacts
 
-RUN mkdir artifacts
 COPY artifacts/Wikibase.tar.gz artifacts
 RUN tar xzf artifacts/Wikibase.tar.gz
 
@@ -27,13 +27,10 @@ FROM ${MEDIAWIKI_IMAGE_NAME}:latest
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends libbz2-dev=1.* gettext-base=0.19.* && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN a2enmod rewrite
-
-RUN install -d /var/log/mediawiki -o www-data
-
-RUN docker-php-ext-install calendar bz2
+    rm -rf /var/lib/apt/lists/* && \
+    a2enmod rewrite && \
+    install -d /var/log/mediawiki -o www-data && \
+    docker-php-ext-install calendar bz2
 
 COPY --from=composer --chown=root:root /var/www/html /var/www/html
 COPY artifacts/wait-for-it.sh /wait-for-it.sh

--- a/Docker/build/WikibaseBundle/Dockerfile
+++ b/Docker/build/WikibaseBundle/Dockerfile
@@ -9,9 +9,9 @@ COPY --from=base --chown=nobody:nogroup /var/www/html /var/www/html
 COPY artifacts/extensions /var/www/html/extensions
 
 WORKDIR /var/www/html/
-RUN rm -rf /var/www/html/vendor
-RUN rm -rf /var/www/html/composer.lock
-RUN composer install --no-dev -vv -n
+RUN rm -rf /var/www/html/vendor && \
+    rm -rf /var/www/html/composer.lock && \
+    composer install --no-dev -vv -n
 
 FROM ${WIKIBASE_IMAGE_NAME}:latest
 RUN rm -rf /var/www/html/vendor

--- a/Docker/publish/download_artifacts/Dockerfile
+++ b/Docker/publish/download_artifacts/Dockerfile
@@ -4,7 +4,7 @@ RUN pip install requests
 
 COPY download_artifacts.py /download_artifacts.py
 
-RUN mkdir /zips
-RUN mkdir /extractedArtifacts
+RUN mkdir /zips && \
+    mkdir /extractedArtifacts
 
 CMD [ "python", "./download_artifacts.py" ]

--- a/Docker/test/selenium/Dockerfile
+++ b/Docker/test/selenium/Dockerfile
@@ -1,9 +1,9 @@
 FROM docker:latest
 
-RUN apk add --update bash chromium chromium-chromedriver alpine-sdk python3 nodejs npm
-RUN ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
+RUN apk add --update bash chromium chromium-chromedriver alpine-sdk python3 nodejs npm && \
+    ln -sf python3 /usr/bin/python && \
+    python3 -m ensurepip && \
+    pip3 install --no-cache --upgrade pip setuptools
 
 WORKDIR /usr/src/app/
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:latest
-RUN apk add --no-cache git make bash python3 py3-pip
-RUN pip3 install pyyaml
+RUN apk add --no-cache git make bash python3 py3-pip && \
+    pip3 install pyyaml
 WORKDIR "/app/"
 ENV XDG_CACHE_HOME=/app/cache
 ADD Docker/build/ Docker/build/


### PR DESCRIPTION
This PR adds dockerfile linting to CI and updates some Dockerfiles to optimize their resulting image size.

In order to enable recursive - multi file linting, some changes were required in the official hadolint github action, which was forked and upstreamed to hadolint/hadolint-action/pull/34. If and when this PR is merged, the GitHub action for linting dockerfiles must be updated.

Bug: T283240 ([link](https://phabricator.wikimedia.org/T283240))