### PR TITLE
Remove some useless cron job + check for last stable

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -1,8 +1,6 @@
 name: Build and test Wikibase and friends
 
 on:
-  schedule:
-    - cron:  '0 */6 * * *'
   workflow_dispatch:
     inputs:
       env_file:
@@ -12,18 +10,9 @@ on:
   push:
 
 env:
-  LAST_RELEASE: 'versions/wmde1.env'
   env_file: ${{ github.event.inputs.env_file || 'versions/wmde1.env' }}
 
 jobs:
-  check_last_stable_mediawiki:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: c-py/action-dotenv-to-setenv@v2
-        with:
-          env-file: ${{ env.LAST_RELEASE }}
-      - run: curl --silent https://www.mediawiki.org/wiki/Template:MW_stable_release_number 2>&1 | grep "$MEDIAWIKI_VERSION"
 
   build_mediawiki:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cron job is currently just eating cpu and not adding any value.
Same thing with the check for last stable version, we aren't bound to
these and don't intend to release 1.36.