### PR TITLE
example .env: move comments to own lines

### DIFF
--- a/example/template.env
+++ b/example/template.env
@@ -1,4 +1,4 @@
-# Image Configuration
+## Image Configuration
 WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.35.2-wmde.1
 WDQS_IMAGE_NAME=wikibase/wdqs:0.3.40-wmde.1
 WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.1
@@ -8,25 +8,27 @@ QUICKSTATEMENTS_IMAGE_NAME=wikibase/quickstatements:wmde.1
 WDQS_PROXY_IMAGE_NAME=wikibase/wdqs-proxy:wmde.1
 MYSQL_IMAGE_NAME=mariadb:10.3
 
-# Mediawiki Configuration
+## Mediawiki Configuration
 MW_ADMIN_NAME=admin
 MW_ADMIN_PASS=change-this-password
 MW_ADMIN_EMAIL=admin@example.com
 MW_SECRET_KEY=some-secret-key
 
-# Database Configuration
+## Database Configuration
 DB_NAME=my_wiki
 DB_USER=sqluser
 DB_PASS=change-this-sqlpassword
 
-# Wikibase Configuration
+## Wikibase Configuration
 WIKIBASE_PINGBACK=false
-WIKIBASE_HOST=wikibase.svc # wikibase.svc is the internal docker hostname, change this value to the public hostname
+# wikibase.svc is the internal docker hostname, change this value to the public hostname
+WIKIBASE_HOST=wikibase.svc
 WIKIBASE_PORT=80
 
-# WDQS-frontend Configuration
+## WDQS-frontend Configuration
 WDQS_FRONTEND_PORT=8834
 
-# Quickstatements Configuration
-QUICKSTATEMENTS_HOST=quickstatements.svc # quickstatements.svc is the internal docker hostname, change this value to the public hostname
+## Quickstatements Configuration
+# quickstatements.svc is the internal docker hostname, change this value to the public hostname
+QUICKSTATEMENTS_HOST=quickstatements.svc
 QUICKSTATEMENTS_PORT=8840

--- a/example/template.env
+++ b/example/template.env
@@ -1,3 +1,6 @@
+## Example / Template .env file for Wikibase release pipeline docker-compose example
+# WARNING: Do not add comments on the same line as env vars, as in some environments they will be included in the var!
+
 ## Image Configuration
 WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.35.2-wmde.1
 WDQS_IMAGE_NAME=wikibase/wdqs:0.3.40-wmde.1


### PR DESCRIPTION
In some environments it appears evaluation of the `.env` can lead to errors, and the comments being included in the env vars.

https://phabricator.wikimedia.org/T286334