### PR TITLE
Add download make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ include .env
 
 export
 
+.PHONY: download
+download:
+	bash publish/download.sh
+
 .PHONY: test
 test:
 	bash test/test_suite.sh ${SUITE}

--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -14,10 +14,13 @@
 
 After the build and test workflow has successfully completed it is time to download the results and prepare to publish it as a release.
 
-This can be done by setting the `WORKFLOW_RUN_NUMBER` variable in your local.env file and source it into the shell and execute the following command.
+This can be done by setting the `WORKFLOW_RUN_NUMBER` variable in your local.env and execute the following command.
 
-```sh
-$ ./publish/download.sh
+```
+$ make download
+...
+Getting artifacts for run 1157808966
+...
 ```
 
 This will download the build, test and metadata artifacts for the workflow run into `artifacts/WORKFLOW_RUN_NUMBER/`


### PR DESCRIPTION
This adds a phony download make target which makes it easiser to
download built artifacts. Now sourcing of .env variables are guaranteed
to happen in the right order and it's only one command.