### PR TITLE
Extend wikibase service instead

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -43,26 +43,23 @@ The wikibase bundle comes with some additional services that can be enabled.
 - quickstatements
 - elasticsearch
 
-### 1. Uncomment the extra-install scripts in `docker-compose.yml` 
-
-In the volumes section of the wikibase service there is one commented line that automatically sets up the extensions needed for the additional services.
+### 1. Run with the extra configuration
 
 ```
+docker-compose -f docker-compose.yml -f docker-compose.extra.yml up
+```
+
+In the volumes section of the wikibase service in [docker-compose.extra.yml](docker-compose.extra.yml) there is one additional script inside the container that automatically sets up the extensions needed for the additional services.
+
+```yml
 - ./extra-install.sh:/extra-install.sh
 ```
 
 Looking inside extra-install.sh it executes two scripts that sets up an OAuth consumer for quickstatements and creates indicies for elasticsearch.
 
-### 2. Uncomment MW_ELASTIC_HOST and MW_ELASTIC_PORT in `docker-compose.yml`
 
-To configure wikibase to use elasticsearch we need to uncomment the following two lines in the example docker-compose.yml file
-```
-      - MW_ELASTIC_HOST=elasticsearch.svc
-      - MW_ELASTIC_PORT=9200
-``` 
-
-### 3. Run with the extra configuration
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.extra.yml up
+There are also additional environment variables passed into wikibase to configure the  elasticsearch host and port.
+```yml
+  MW_ELASTIC_HOST: ${MW_ELASTIC_HOST}
+  MW_ELASTIC_PORT: ${MW_ELASTIC_PORT}
 ```

--- a/example/docker-compose.extra.yml
+++ b/example/docker-compose.extra.yml
@@ -2,6 +2,12 @@
 version: '3.4'
 
 services:
+  wikibase:
+    volumes:
+      - ./extra-install.sh:/extra-install.sh
+    environment:
+        MW_ELASTIC_HOST: ${MW_ELASTIC_HOST}
+        MW_ELASTIC_PORT: ${MW_ELASTIC_PORT}
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_NAME}"
     restart: unless-stopped

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -12,8 +12,6 @@ x-common-variables: &wikibase_variables
   DB_USER: ${DB_USER}
   DB_PASS: ${DB_PASS}
   DB_NAME: ${DB_NAME}
-  #MW_ELASTIC_HOST: elasticsearch.svc
-  #MW_ELASTIC_PORT: 9200
   WIKIBASEHOST:
   QS_PUBLIC_SCHEME_HOST_AND_PORT: http://${QUICKSTATEMENTS_HOST}:${QUICKSTATEMENTS_PORT}
 
@@ -29,15 +27,12 @@ services:
       - "${WIKIBASE_PORT}:80"
     volumes:
       - quickstatements-data:/quickstatements/data
-
       ## This shares the configuration with jobrunner
       - shared:/var/www/html/:rw
-      
-      ## Uncomment this next line to enable installation of additional services
-      #- ./extra-install.sh:/extra-install.sh
 
       ## Uncomment this next line to mount your own LocalSettings.php file
       #- ./LocalSettings.php:/var/www/html/LocalSettings.d/LocalSettings.override.php
+
     networks:
       default:
         aliases:

--- a/example/template.env
+++ b/example/template.env
@@ -38,3 +38,7 @@ WDQS_FRONTEND_PORT=8834
 # quickstatements.svc is the internal docker hostname, change this value to the public hostname
 QUICKSTATEMENTS_HOST=quickstatements.svc
 QUICKSTATEMENTS_PORT=8840
+
+## ElasticSearch
+MW_ELASTIC_HOST=elasticsearch.svc
+MW_ELASTIC_PORT=9200

--- a/test/test_example.sh
+++ b/test/test_example.sh
@@ -14,6 +14,5 @@ mkdir -p log
 cp template.env .env
 
 # uncomment extra-install scripts
-sed -i '16,22 s/#//' docker-compose.yml
 docker-compose -f docker-compose.yml -f docker-compose.extra.yml up -d
 docker-compose -f docker-compose.yml -f docker-compose.extra.yml logs -f --no-color > "log/example.log" &


### PR DESCRIPTION
Instead of telling the users to uncomment lines and specify env
variables we can do that already by just adding it to the wikibase
service in the docker-compose.extra.yml file