### PR TITLE
Update reporter to show skipped tests

### DIFF
--- a/Docker/test/selenium/json-reporter.js
+++ b/Docker/test/selenium/json-reporter.js
@@ -12,8 +12,13 @@ class JsonReporter extends reporter.default {
 
 		this.failures = [];
 		this.success = [];
+		this.skipped = [];
 	}
-
+	onTestSkip( test ) {
+		this.skipped.push( {
+			fullTitle: test.fullTitle
+		} );
+	}
 	onTestPass( test ) {
 		this.success.push( {
 			fullTitle: test.fullTitle
@@ -30,7 +35,8 @@ class JsonReporter extends reporter.default {
 
 		const result = {
 			fail: this.failures,
-			pass: this.success
+			pass: this.success,
+			skip: this.skipped
 		};
 
 		const suite = process.env.SUITE || 'unknown';
@@ -43,6 +49,7 @@ class JsonReporter extends reporter.default {
 			if ( existing ) {
 				result.pass = result.pass.concat( existing.pass );
 				result.fail = result.fail.concat( existing.fail );
+				result.skip = result.skip.concat( existing.skip );
 			}
 		}
 

--- a/test/reporter/report.js
+++ b/test/reporter/report.js
@@ -36,6 +36,10 @@ if (fs.existsSync(filePath)) {
             core.info( 'OK: ' + test.fullTitle );
         });
 
+        resultObject.skip.forEach(test => {
+            core.warning( 'SKIP: ' + test.fullTitle );
+        });
+
         core.info('\u001b[1mAll good 👍')
     }
 } else {


### PR DESCRIPTION
If tests are skipped they are currently not shown in the report, which
makes it trickier to determine what actually happened.

This adds skips tests and shows them at the end.