### PR TITLE
Use node image to build wdqs-frontend

### DIFF
--- a/Docker/build/WDQS-frontend/Dockerfile
+++ b/Docker/build/WDQS-frontend/Dockerfile
@@ -6,15 +6,14 @@ RUN mkdir wikidata-query-gui \
     && tar xfv $tarball -C ./wikidata-query-gui \
     && rm $tarball
 
-# TODO this should probably just be a node image?
-FROM nginx:stable-alpine as builder
+FROM node:14-alpine as builder
 
 COPY --from=fetcher /wikidata-query-gui /tmp/wikidata-query-gui
 
 WORKDIR /tmp/wikidata-query-gui
 
 # install dependencies
-RUN apk --no-cache add --virtual build-dependencies ca-certificates git~=2.30 nodejs~=14 npm~=14 jq~=1.6 make~=4.3 g++~=10.2
+RUN apk --no-cache add --virtual build-dependencies ca-certificates git jq make g++
 
 # TODO do npm build instead of leaving any dev node modules hanging around
 RUN mv package.json package.json.orig \


### PR DESCRIPTION
These started failing yesterday, lets stop installing node/npm ourselves and use a prepared image as the TODO says.

```
https://github.com/wmde/wikibase-release-pipeline/runs/4229621592?check_suite_focus=true

ERROR: unable to select packages:
  git-2.32.0-r0:
    breaks: build-dependencies-20211116.193615[git~2.30]
  npm-7.17.0-r0:
    breaks: build-dependencies-20211116.193615[npm~14]
  g++-10.3.1_git20210424-r2:
    breaks: build-dependencies-20211116.193615[g++~10.2]
```