### PR TITLE
Add scanning of each docker image

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -1,0 +1,38 @@
+name: 'scan-docker'
+description: 'Scan image and upload results'
+inputs:
+  image_tag:
+    description: 'tag to give to latest image'
+    required: true
+  image_name:
+    description: 'name of the docker image to work with'
+    required: true
+runs:
+  using: "composite"
+  steps:
+      - uses: anchore/scan-action@v3
+        id: scan
+        with:
+          acs-report-enable: true
+          severity-cutoff: critical
+          fail-build: false
+          image: ${{ inputs.image_name }}:${{ inputs.image_tag }}
+
+      # uploads it to the ui
+      - uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
+      # output to terminal and move to non-conflicting name
+      - name: Inspect action SARIF report 
+        shell: bash
+        run: |
+          cat ${{ steps.scan.outputs.sarif }}
+          mv ${{ steps.scan.outputs.sarif }} /tmp/${{ inputs.image_name }}.sarif
+
+      - name: Archive docker production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ScanArtifacts
+          if-no-files-found: error
+          path: /tmp/${{ inputs.image_name }}.sarif

--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -82,6 +82,12 @@ jobs:
           if-no-files-found: error
           path: artifacts/wikibase.docker.tar.gz
 
+      - name: Scan image
+        uses: ./.github/actions/scan-image
+        with:
+          image_name: ${{ env.WIKIBASE_IMAGE_NAME }}
+          image_tag: latest
+
   build_wikibase_bundle:
     runs-on: ubuntu-latest
     needs:
@@ -151,6 +157,12 @@ jobs:
           if-no-files-found: error
           path: artifacts/build_metadata_*.env
 
+      - name: Scan image
+        uses: ./.github/actions/scan-image
+        with:
+          image_name: ${{ env.WIKIBASE_BUNDLE_IMAGE_NAME }}
+          image_tag: latest
+
   build_quickstatements:
     runs-on: ubuntu-latest
     steps:
@@ -175,6 +187,13 @@ jobs:
           if-no-files-found: error
           path: artifacts/build_metadata_*.env
 
+      - name: Archive docker production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: BuildArtifacts
+          if-no-files-found: error
+          path: artifacts/quickstatements.docker.tar.gz
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         if: github.ref == 'refs/heads/main'
@@ -190,12 +209,11 @@ jobs:
           image_name: ${{ env.QUICKSTATEMENTS_IMAGE_NAME }}
           tag: ${{ github.run_id }}
 
-      - name: Archive docker production artifacts
-        uses: actions/upload-artifact@v2
+      - name: Scan image
+        uses: ./.github/actions/scan-image
         with:
-          name: BuildArtifacts
-          if-no-files-found: error
-          path: artifacts/quickstatements.docker.tar.gz
+          image_name: ${{ env.QUICKSTATEMENTS_IMAGE_NAME }}
+          image_tag: latest
 
   build_wdqs:
     runs-on: ubuntu-latest
@@ -244,6 +262,12 @@ jobs:
           if-no-files-found: error
           path: artifacts/wdqs.docker.tar.gz
 
+      - name: Scan image
+        uses: ./.github/actions/scan-image
+        with:
+          image_name: ${{ env.WDQS_IMAGE_NAME }}
+          image_tag: latest
+
   build_wdqs_proxy:
     runs-on: ubuntu-latest
     steps:
@@ -281,6 +305,12 @@ jobs:
           name: BuildArtifacts
           if-no-files-found: error
           path: artifacts/wdqs-proxy.docker.tar.gz
+
+      - name: Scan image
+        uses: ./.github/actions/scan-image
+        with:
+          image_name: ${{ env.WDQS_PROXY_IMAGE_NAME }}
+          image_tag: latest
 
   build_wdqs_frontend:
     runs-on: ubuntu-latest
@@ -342,6 +372,12 @@ jobs:
           image_name: ${{ env.WDQS_FRONTEND_IMAGE_NAME }}
           tag: ${{ github.run_id }}
 
+      - name: Scan image
+        uses: ./.github/actions/scan-image
+        with:
+          image_name: ${{ env.WDQS_FRONTEND_IMAGE_NAME }}
+          image_tag: latest
+
   build_elasticsearch:
     runs-on: ubuntu-latest
     steps:
@@ -379,6 +415,12 @@ jobs:
         with:
           image_name: ${{ env.ELASTICSEARCH_IMAGE_NAME }}
           tag: ${{ github.run_id }}
+
+      - name: Scan image
+        uses: ./.github/actions/scan-image
+        with:
+          image_name: ${{ env.ELASTICSEARCH_IMAGE_NAME }}
+          image_tag: latest
 
   test_wikibase:
     strategy:


### PR DESCRIPTION
One way of trying this out with the full UI integration could be to:

1. Fork my fork https://github.com/toban/wikibase-release-pipeline/tree/add-scan
2. Enable github actions on your fork
3. Merge add-scan to main of your fork or run the main workflow on add-scan