### PR TITLE
[T296066.2] Fix elasticsearch tests getting stuck

### DIFF
--- a/Docker/test/selenium/specs/elasticsearch/elasticsearch.js
+++ b/Docker/test/selenium/specs/elasticsearch/elasticsearch.js
@@ -11,6 +11,45 @@ describe( 'ElasticSearch', function () {
 
 	let itemId = null;
 
+	it( 'Should able able to run UpdateSearchIndexConfig.php', function () {
+
+		const result = browser.dockerExecute(
+			process.env.DOCKER_WIKIBASE_REPO_NAME,
+			'php extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php --startOver'
+		);
+
+		assert( result.includes( 'content index...' ) === true );
+		assert( result.includes( 'general index...' ) === true );
+		assert( result.includes( 'archive index...' ) === true );
+
+	} );
+
+	it( 'Should be able to run ForceSearchIndex.php', function () {
+
+		// run jobs detached
+		browser.dockerExecute(
+			process.env.DOCKER_WIKIBASE_REPO_NAME,
+			"bash -c 'php /var/www/html/maintenance/runJobs.php --wiki my_wiki --wait --maxjobs 2 > /var/log/runJobs.log'",
+			'--detach'
+		);
+
+		const resultCommand = browser.dockerExecute(
+			process.env.DOCKER_WIKIBASE_REPO_NAME,
+			'php extensions/CirrusSearch/maintenance/ForceSearchIndex.php --queue --maxJobs 10000 --pauseForJobs 1000 --skipLinks --indexOnSkip'
+		);
+
+		const logResult = browser.dockerExecute(
+			process.env.DOCKER_WIKIBASE_REPO_NAME,
+			'cat /var/log/runJobs.log'
+		);
+
+		assert( logResult.includes( 'cirrusSearchMassIndex Special: pageDBKeys=["Main_Page","Item:Q1"]' ) === true );
+		assert( logResult.includes( 'cirrusSearchElasticaWrite' ) === true );
+
+		// should have queued some stuff
+		assert( resultCommand.includes( 'Queued a total of' ) === true );
+	} );
+
 	it( 'Should create an item', function () {
 
 		itemId = browser.call(

--- a/test/suite-config/elasticsearch/docker-compose.override.yml
+++ b/test/suite-config/elasticsearch/docker-compose.override.yml
@@ -19,8 +19,6 @@ services:
     environment: 
       - MW_ELASTIC_HOST=elasticsearch.svc
       - MW_ELASTIC_PORT=9200
-    volumes:
-      - ./suite-config/elasticsearch/wikibase/extra-install.sh:/extra-install.sh
 
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_NAME}"

--- a/test/suite-config/elasticsearch/wikibase/extra-install.sh
+++ b/test/suite-config/elasticsearch/wikibase/extra-install.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ex
-
-bash /extra-install/ElasticSearch.sh


### PR DESCRIPTION
the reinstates the old way of initializing elasticsearch by doing it in the tests rather than relying on extra-install.