### PR TITLE
Add source to all images

### DIFF
--- a/Docker/build/Elasticsearch/Dockerfile
+++ b/Docker/build/Elasticsearch/Dockerfile
@@ -6,3 +6,5 @@ RUN ./bin/elasticsearch-plugin install org.wikimedia.search:extra:${ELASTICSEARC
 
 ARG ELASTICSEARCH_VERSION
 RUN ./bin/elasticsearch-plugin install org.wikimedia.search.highlighter:experimental-highlighter-elasticsearch-plugin:${ELASTICSEARCH_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/Mediawiki/Dockerfile
+++ b/Docker/build/Mediawiki/Dockerfile
@@ -61,3 +61,5 @@ RUN tar -x --strip-components=1 -f /tmp/mediawiki.tar.gz && \
 	chown -R www-data:www-data extensions skins cache images;
 
 CMD ["apache2-foreground"]
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/QuickStatements/Dockerfile
+++ b/Docker/build/QuickStatements/Dockerfile
@@ -42,3 +42,5 @@ RUN install -d -owww-data /var/log/quickstatements
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/entrypoint.sh"]
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/WDQS-frontend/Dockerfile
+++ b/Docker/build/WDQS-frontend/Dockerfile
@@ -41,3 +41,5 @@ ENV LANGUAGE=en\
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/WDQS-proxy/Dockerfile
+++ b/Docker/build/WDQS-proxy/Dockerfile
@@ -6,3 +6,5 @@ COPY wdqs.template /etc/nginx/conf.d/wdqs.template
 ENV PROXY_MAX_QUERY_MILLIS=60000
 
 ENTRYPOINT "/entrypoint.sh"
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/WDQS/Dockerfile
+++ b/Docker/build/WDQS/Dockerfile
@@ -41,3 +41,5 @@ COPY --chown=blazegraph:blazegraph RWStore.properties whitelist.txt /wdqs/
 RUN chmod +x /wdqs/runUpdate.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/Wikibase/Dockerfile
+++ b/Docker/build/Wikibase/Dockerfile
@@ -49,3 +49,5 @@ RUN chown www-data ${MW_WG_UPLOAD_DIRECTORY} -R
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/entrypoint.sh"]
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"

--- a/Docker/build/WikibaseBundle/Dockerfile
+++ b/Docker/build/WikibaseBundle/Dockerfile
@@ -27,3 +27,5 @@ COPY LocalSettings.d /var/www/html/LocalSettings.d
 
 ARG INSTALLED_EXTENSIONS
 ENV INSTALLED_EXTENSIONS=${INSTALLED_EXTENSIONS}
+
+LABEL org.opencontainers.image.source="https://github.com/wmde/wikibase-release-pipeline"


### PR DESCRIPTION
This adds org.opencontainers.image.source in an attempt to fix missing repo link on dockerhub