### PR TITLE
Switch back to upcoming REL1_36 release

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -10,7 +10,7 @@ on:
   push:
 
 env:
-  env_file: ${{ github.event.inputs.env_file || 'versions/wmde3.env' }}
+  env_file: ${{ github.event.inputs.env_file || 'versions/wmde4.env' }}
 
 jobs:
 

--- a/versions/wmde4.env
+++ b/versions/wmde4.env
@@ -13,10 +13,10 @@ BUNDLE_EXT_EXTENSIONS=WikibaseLocalMedia,WikibaseEdtf
 BUNDLE_WMF_EXTENSIONS=Babel,cldr,CirrusSearch,ConfirmEdit,Elastica,EntitySchema,Nuke,OAuth,Scribunto,SyntaxHighlight_GeSHi,UniversalLanguageSelector,VisualEditor,WikibaseCirrusSearch,WikibaseManifest
 
 MEDIAWIKI_MAJOR_VERSION=1.36
-MEDIAWIKI_VERSION=1.36.2
+MEDIAWIKI_VERSION=1.36.3
 
 RELEASE_MAJOR_VERSION=1.36
-RELEASE_VERSION=1.36.2
+RELEASE_VERSION=1.36.3
 
 ELASTICSEARCH_VERSION=6.5.4
 


### PR DESCRIPTION
- changes to build wmde.4
- bumps the MW base image to 1.36.3