### PR TITLE
Tweak some timeouts for the pipeline

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -485,6 +485,7 @@ jobs:
           path: test/log
 
   test_upgrade_base:
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -520,6 +521,7 @@ jobs:
           path: test/log
 
   test_upgrade_bundle:
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -456,7 +456,7 @@ jobs:
       - build_wdqs_proxy
       - build_quickstatements
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - name: Get Wikibase docker image artifact

--- a/Docker/test/selenium/specs/elasticsearch/elasticsearch.js
+++ b/Docker/test/selenium/specs/elasticsearch/elasticsearch.js
@@ -55,7 +55,7 @@ describe( 'ElasticSearch', function () {
 					searchResult[ 0 ].match.text === itemLabel;
 			},
 			{
-				timeout: 10000,
+				timeout: 20000,
 				timeoutMsg: 'Elasticsearch should have updated the label by now.'
 			}
 		);
@@ -81,7 +81,7 @@ describe( 'ElasticSearch', function () {
 					searchResult[ 0 ].match.text === itemAlias;
 			},
 			{
-				timeout: 10000,
+				timeout: 20000,
 				timeoutMsg: 'Elasticsearch should have updated the alias by now.'
 			}
 		);


### PR DESCRIPTION
- Set a timeout for test-upgrade base + bundle
- Lower timeout of normal tests to 15 minutes, it should never take 30 minutes. 
- Increase timeouts of elasticsearch.js tests as they seem a bit flaky now.