### PR TITLE
Make the names of the wikibase instance and WDQS adjustable in the settings

### DIFF
--- a/Docker/build/QuickStatements/config.json
+++ b/Docker/build/QuickStatements/config.json
@@ -4,6 +4,7 @@
 	"logfile" : "/var/log/quickstatements/tool.log" ,
 	"sites" : {
 		"${MW_SITE_NAME}" : {
+			"label" : "${MW_SITE_NAME}",
 			"oauth" : {
 				"language":"${MW_SITE_LANG}" ,
 				"project":"${MW_SITE_NAME}" ,

--- a/Docker/build/WDQS-frontend/Dockerfile
+++ b/Docker/build/WDQS-frontend/Dockerfile
@@ -36,7 +36,6 @@ COPY custom-config.json /templates/custom-config.json
 COPY default.conf /templates/default.conf
 
 ENV LANGUAGE=en\
-    BRAND_TITLE=DockerWikibaseQueryService\
     COPYRIGHT_URL=undefined
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Docker/build/WDQS-frontend/custom-config.json
+++ b/Docker/build/WDQS-frontend/custom-config.json
@@ -15,7 +15,7 @@
       "urlShortener": "tinyurl"
     },
     "brand": {
-      "title": "$BRAND_TITLE",
+      "title": "${WDQS_NAME}",
       "logo": "logo.svg",
       "favicon": "favicon.ico",
       "copyrightUrl": "$COPYRIGHT_URL",

--- a/example/docker-compose.extra.yml
+++ b/example/docker-compose.extra.yml
@@ -115,6 +115,7 @@ services:
       - "WB_ITEM_PREFIX=Item:"
       - OAUTH_CONSUMER_KEY=${OAUTH_CONSUMER_KEY}
       - OAUTH_CONSUMER_SECRET=${OAUTH_CONSUMER_SECRET}
+      - MW_SITE_NAME=${MW_SITE_NAME}
 
 volumes:
   LocalSettings:

--- a/example/docker-compose.extra.yml
+++ b/example/docker-compose.extra.yml
@@ -45,6 +45,7 @@ services:
     environment:
       - WIKIBASE_HOST=${WIKIBASE_HOST}
       - WDQS_HOST=wdqs-proxy.svc
+      - WDQS_NAME=${WDQS_NAME}
   wdqs:
     image: "${WDQS_IMAGE_NAME}"
     restart: unless-stopped

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       <<: *wikibase_variables
       WIKIBASE_PINGBACK:
       MW_WG_ENABLE_UPLOADS:
+      MW_SITE_NAME: ${MW_SITE_NAME}
 
   wikibase_jobrunner:
     image: "${WIKIBASE_BUNDLE_IMAGE_NAME}"

--- a/example/template.env
+++ b/example/template.env
@@ -22,6 +22,7 @@ MW_ADMIN_NAME=admin
 MW_ADMIN_EMAIL=admin@example.com
 MW_SECRET_KEY=some-secret-key
 MW_WG_ENABLE_UPLOADS=false
+MW_SITE_NAME=wikibase-docker
 
 ## Jobrunner Configuration
 MAX_JOBS=1

--- a/example/template.env
+++ b/example/template.env
@@ -41,6 +41,7 @@ WIKIBASE_PORT=80
 ## WDQS-frontend Configuration
 WDQS_FRONTEND_HOST=wdqs-frontend.svc
 WDQS_FRONTEND_PORT=8834
+WDQS_NAME=DockerWikibaseQueryService
 
 ## Quickstatements Configuration
 # quickstatements.svc is the internal docker hostname, change this value to the public hostname


### PR DESCRIPTION
These commits make the names of the wikibase instance and the query service adjustable via the .env file and the names are then properly displayed in Wikibase (added to the LocalSettings), Quickstatements (name of the wikibase to edit) and the query service (which is displayed in the front-end).

I created these changes for a project I am working on and thought they are useful and generic enough to benefit everybody who is installing a new wikibase. Please let me know what you think.