### PR TITLE
Add comment on MW_ELASTIC_HOST

### DIFF
--- a/example/template.env
+++ b/example/template.env
@@ -47,5 +47,7 @@ QUICKSTATEMENTS_HOST=quickstatements.svc
 QUICKSTATEMENTS_PORT=8840
 
 ## ElasticSearch
+## Comment out MW_ELASTIC_HOST to disable ElasticsSearch
+## See https://github.com/wmde/wikibase-release-pipeline/blob/wmde.4/Docker/build/WikibaseBundle/LocalSettings.d.template/WikibaseCirrusSearch.php#L6
 MW_ELASTIC_HOST=elasticsearch.svc
 MW_ELASTIC_PORT=9200


### PR DESCRIPTION
MW_ELASTIC_HOST gets checked at runtime if it's set in order to switch between Elasticsearch / Wikibase Search. Add a comment in the template to make this more clear.