### PR TITLE
docker run --rm for publish steps

### DIFF
--- a/publish/dockerhub.sh
+++ b/publish/dockerhub.sh
@@ -2,5 +2,5 @@
 set -e
 
 cd publish
-docker-compose build download_artifacts && docker-compose run download_artifacts
-docker-compose build upload_dockerhub && docker-compose run upload_dockerhub --rm
+docker-compose build download_artifacts && docker-compose run --rm download_artifacts
+docker-compose build upload_dockerhub && docker-compose run --rm upload_dockerhub

--- a/publish/download.sh
+++ b/publish/download.sh
@@ -3,4 +3,4 @@ set -e
 
 cd publish
 
-docker-compose build download_artifacts && docker-compose run download_artifacts
+docker-compose build download_artifacts && docker-compose run --rm download_artifacts

--- a/publish/git_tag.sh
+++ b/publish/git_tag.sh
@@ -2,5 +2,5 @@
 set -e
 
 cd publish
-docker-compose build download_artifacts && docker-compose run download_artifacts
-docker-compose build tag_git && docker-compose run tag_git --rm
+docker-compose build download_artifacts && docker-compose run --rm download_artifacts
+docker-compose build tag_git && docker-compose run --rm tag_git

--- a/publish/tar.sh
+++ b/publish/tar.sh
@@ -2,5 +2,5 @@
 set -e
 
 cd publish
-docker-compose build download_artifacts && docker-compose run download_artifacts
-docker-compose build upload_tar && docker-compose run upload_tar --rm
+docker-compose build download_artifacts && docker-compose run --rm download_artifacts
+docker-compose build upload_tar && docker-compose run --rm upload_tar


### PR DESCRIPTION
Without this if I run the dockerhub publish step
(or any other publish step) ~42GB of my disk space
gets used due to the dind conteext being a docker
volume that will never be auto cleaned.
