### PR TITLE
Use hadolint/hadolint-action@v1.6.0 (recursive)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # TODO: Replace with the official hadolint/hadolint-action once change is upstreamed
-      - uses: itamargiv/hadolint-action@v1.5.1-h
+      - uses: hadolint/hadolint-action@v1.6.0
         with:
           recursive: true
 


### PR DESCRIPTION
https://github.com/hadolint/hadolint-action/pull/34
was merged and released, so we can make use of this
rather than the custom version.
