### PR TITLE
docs: publishing: Update example images before tagging

### DIFF
--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -126,6 +126,18 @@ set -o allexport; source versions/<RELEASE_ENV>; source variables.env; source lo
 
 After successfully uploading the tarballs they should be accessible at https://releases.wikimedia.org/wikibase/
 
+## Update the example docker-compose
+
+Once the release images are pushed to docker hub, and BEFORE tagging this repository the docker-compose example should be updated to point to the new release on docker hub.
+
+This is so that we can link to the example, using the tag that we will create in the next step.
+
+The version used should be the latest release of the latest currently supported version of the images.
+
+Take a look at the `.env` file in the `example` directory and udpate the image tags.
+
+Example commit: https://github.com/wmde/wikibase-release-pipeline/commit/73f9942ebd92ded5f17fbb7f8537e9f2268e2bc4
+
 ## Publish git tags
 
 ### Tag this repository

--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -134,7 +134,7 @@ This is so that we can link to the example, using the tag that we will create in
 
 The version used should be the latest release of the latest currently supported version of the images.
 
-Take a look at the `.env` file in the `example` directory and udpate the image tags.
+Take a look at the `.env` file in the `example` directory and update the image tags.
 
 Example commit: https://github.com/wmde/wikibase-release-pipeline/commit/73f9942ebd92ded5f17fbb7f8537e9f2268e2bc4
 


### PR DESCRIPTION
I ran into this issue when doing the wmde.5 release, where
I followed the docs, tagged the image, and then when trying
to update links to the example I realized that I could not
link to the tag (what was done previously).

Looking at the git history this is also not the first time
this has happened, and folks have deleted tags on the repo
so they could re tag after then updating the example.

So document this step in the order of releasing.
