### PR TITLE
Error when download_artifacts.py gets non 200 responses

### DIFF
--- a/Docker/publish/download_artifacts/download_artifacts.py
+++ b/Docker/publish/download_artifacts/download_artifacts.py
@@ -11,6 +11,11 @@ r = requests.get(artifactsPath,  headers=headers)
 basepath = os.path.join('/extractedArtifacts', os.getenv('WORKFLOW_RUN_NUMBER'))
 artifactsMetadata =  r.json()
 
+if r.status_code != 200:
+    print('Non 200 response reseived: %s' % r.status_code)
+    print(r.text)
+    exit(1)
+
 if artifactsMetadata['total_count'] == 0:
     raise Exception("This run does not contain any artifacts to publish!") 
 


### PR DESCRIPTION
I was running this, and clearly had something setup wrong
but the failure message was not helpful.
Now we get the error from github if returned that should
help users determine what is going on.
