### PR TITLE
Bump all github action cache keys (include v3)

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -40,7 +40,7 @@ jobs:
           cache-name: cache-wikibase-composer
         with:
           path: cache
-          key: cache-wikibase-composer
+          key: cachev3-wikibase-composer
 
       - name: Cache git_cache repos
         uses: actions/cache@v3
@@ -48,7 +48,7 @@ jobs:
           cache-name: cache-wikibase-git-repo-temp-bump
         with:
           path: git_cache
-          key: cache-wikibase-git-repo-temp-bump
+          key: cachev3-wikibase-git-repo-temp-bump
 
       - name: Build Tarball
         run: bash build.sh wikibase ${{ env.env_file }}
@@ -118,7 +118,7 @@ jobs:
           cache-name: cache-wikibase-composer
         with:
           path: cache
-          key: cache-wikibase-composer
+          key: cachev3-wikibase-composer
 
       - name: Cache git_cache repos
         uses: actions/cache@v3
@@ -126,7 +126,7 @@ jobs:
           cache-name: cache-wikibase-git-repo-temp-bump
         with:
           path: git_cache
-          key: cache-wikibase-git-repo-temp-bump
+          key: cachev3-wikibase-git-repo-temp-bump
 
       - name: Get dependency build artifacts
         uses: actions/download-artifact@v2
@@ -247,7 +247,7 @@ jobs:
           cache-name: cache-wdqs-backend-git-repo
         with:
           path: cache
-          key: cache-wdqs-backend-git-repo
+          key: cachev3-wdqs-backend-git-repo
 
       - name: Build WDQS Image 
         id: download_step
@@ -348,7 +348,7 @@ jobs:
           cache-name: cache-wdqs-frontend-git-repo
         with:
           path: git_cache
-          key: cache-wdqs-frontend-git-repo
+          key: cachev3-wdqs-frontend-git-repo
 
       - name: Build WDQS-frontend
         run: bash build.sh wdqs-frontend ${{ env.env_file }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: npm-lint-cache
+          key: cachev3-npm-lint
       - name: lint the selenium javascript tests
         run: |
           cd Docker/test/selenium 
@@ -51,7 +51,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: npm-lint-cache
+          key: cachev3-npm-lint
       - name: lint the selenium javascript tests
         run: |
           cd diagrams


### PR DESCRIPTION
Seemingly CI broke after bumping the cache action to v3
So let's try bumping the keys to see if this resolved things...
