### PR TITLE
This -temp-bump is not longer needed

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Cache git_cache repos
         uses: actions/cache@v3
         env:
-          cache-name: cache-wikibase-git-repo-temp-bump
+          cache-name: cache-wikibase-git-repo
         with:
           path: git_cache
-          key: cache-wikibase-git-repo-temp-bump
+          key: cache-wikibase-git-repo
 
       - name: Build Tarball
         run: bash build.sh wikibase ${{ env.env_file }}
@@ -123,10 +123,10 @@ jobs:
       - name: Cache git_cache repos
         uses: actions/cache@v3
         env:
-          cache-name: cache-wikibase-git-repo-temp-bump
+          cache-name: cache-wikibase-git-repo
         with:
           path: git_cache
-          key: cache-wikibase-git-repo-temp-bump
+          key: cache-wikibase-git-repo
 
       - name: Get dependency build artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This was added to resolve some caching issues while updating a
github action, but should not be needed any more.
Cleanup to avoid confusing people as to why this is in the key.
