### PR TITLE
fix quickstatements oauth env var test

### DIFF
--- a/Docker/build/QuickStatements/entrypoint.sh
+++ b/Docker/build/QuickStatements/entrypoint.sh
@@ -9,7 +9,7 @@ for i in "${REQUIRED_VARIABLES[@]}"; do
     fi
 done
 
-if [[ -v "$OAUTH_CONSUMER_KEY" && "$OAUTH_CONSUMER_SECRET" ]]; then
+if [[ -v OAUTH_CONSUMER_KEY && -v OAUTH_CONSUMER_SECRET ]]; then
     envsubst < /templates/oauth.ini > /quickstatements/data/oauth.ini;
 fi
 


### PR DESCRIPTION
bash -v takes env var name
https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html#:~:text=Set%20Builtin).-,%2Dv,-varname