### PR TITLE
Set 10min timeout for the make test-upgrade steps

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -524,6 +524,9 @@ jobs:
           path: artifacts/
 
       - name: Test upgrade version - ${{ matrix.version }}
+        # This step should only take ~5 mins to complete, but sometimes seems to lock up and use the whole job timeout
+        # Set a specific lower timeout to allow us to retry sooner
+        timeout-minutes: 10
         run: make test-upgrade VERSION=${{ matrix.version }} TO_VERSION=${{ env.env_file }}
 
       - name: Archive docker test artifacts
@@ -557,6 +560,9 @@ jobs:
           path: artifacts/
 
       - name: Test upgrade version - ${{ matrix.version }}
+        # This step should only take ~5 mins to complete, but sometimes seems to lock up and use the whole job timeout
+        # Set a specific lower timeout to allow us to retry sooner
+        timeout-minutes: 10
         run: make test-upgrade VERSION=${{ matrix.version }} TO_VERSION=${{ env.env_file }}
 
       - name: Archive docker test artifacts


### PR DESCRIPTION
This step often causes the workflow to timeout at
20 mins.
It happens due to something getting stuck in this step.
This step generally takes 5 mins or less to complete.

Force it to timeout earlier so we can retry CI sooner
