### PR TITLE
publishing.md docs, load variables.env before release env

### DIFF
--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -28,6 +28,7 @@ This can be made automatically by CI if it is configured for your release, or al
 Some of the prerequisutes can be used between publications, others needs to be set each time we want to publish a new release.
 
 - Set `WORKFLOW_RUN_NUMBER` in your `local.env` file to the run you with to publish as a release (This will come from the summary page `actions/runs/<WORKFLOW_RUN_NUMBER>`)
+- You should also write this run number next to the release in `CHANGES.md`
 
 ### Download release artifacts
 
@@ -155,7 +156,7 @@ Run with in the terminal
 *(Will ask you for the password to the identity file once)*
 
 ```
-set -o allexport; source versions/<RELEASE_ENV>; source variables.env; source local.env; set +o allexport
+set -o allexport; source variables.env; source versions/<RELEASE_ENV>; source local.env; set +o allexport
 ./publish/tar.sh
 ```
 

--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -28,7 +28,6 @@ This can be made automatically by CI if it is configured for your release, or al
 Some of the prerequisutes can be used between publications, others needs to be set each time we want to publish a new release.
 
 - Set `WORKFLOW_RUN_NUMBER` in your `local.env` file to the run you with to publish as a release (This will come from the summary page `actions/runs/<WORKFLOW_RUN_NUMBER>`)
-- You should also write this run number next to the release in `CHANGES.md`
 
 ### Download release artifacts
 

--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -105,7 +105,7 @@ DRY_RUN="" ./command.sh
 This will load the default `variables.env` file with your `local.env` overriding defaults where appropriate.
 
 ```sh
-set -o allexport; source versions/<RELEASE_ENV>; source variables.env; source local.env; set +o allexport
+set -o allexport; source variables.env; source versions/<RELEASE_ENV>; source local.env; set +o allexport
 ```
 
 ## Publish to dockerhub


### PR DESCRIPTION
Wrong order of source commands might generated not wanted package names that get published