### PR TITLE
Always output docker logs in CI

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -483,12 +483,16 @@ jobs:
           DATABASE_IMAGE_NAME: ${{ matrix.databaseImageName }}
         run: make test SUITE=${{ matrix.suite }}
 
-      - name: Report
+      - name: Report Selenium
         if: always()
         run: |
           cd test/reporter
           npm install
           SUITE=${{ matrix.suite }} node report.js
+
+      - name: docker logs
+        if: always()
+        run: tests/docker_logs.sh
 
       - name: Archive docker test artifacts
         uses: actions/upload-artifact@v3
@@ -529,6 +533,10 @@ jobs:
         timeout-minutes: 10
         run: make test-upgrade VERSION=${{ matrix.version }} TO_VERSION=${{ env.env_file }}
 
+      - name: docker logs
+        if: always()
+        run: tests/docker_logs.sh
+
       - name: Archive docker test artifacts
         uses: actions/upload-artifact@v3
         if: always()
@@ -564,6 +572,10 @@ jobs:
         # Set a specific lower timeout to allow us to retry sooner
         timeout-minutes: 10
         run: make test-upgrade VERSION=${{ matrix.version }} TO_VERSION=${{ env.env_file }}
+
+      - name: docker logs
+        if: always()
+        run: tests/docker_logs.sh
 
       - name: Archive docker test artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -492,7 +492,7 @@ jobs:
 
       - name: docker logs
         if: always()
-        run: tests/docker_logs.sh
+        run: test/docker_logs.sh
 
       - name: Archive docker test artifacts
         uses: actions/upload-artifact@v3
@@ -535,7 +535,7 @@ jobs:
 
       - name: docker logs
         if: always()
-        run: tests/docker_logs.sh
+        run: test/docker_logs.sh
 
       - name: Archive docker test artifacts
         uses: actions/upload-artifact@v3
@@ -575,7 +575,7 @@ jobs:
 
       - name: docker logs
         if: always()
-        run: tests/docker_logs.sh
+        run: test/docker_logs.sh
 
       - name: Archive docker test artifacts
         uses: actions/upload-artifact@v3

--- a/test/docker_logs.sh
+++ b/test/docker_logs.sh
@@ -6,5 +6,5 @@ set -e
 for container in $(docker ps --all | awk '{if(NR>1) print $NF}')
 do
   echo "Container: $container"
-  docker logs $container
+  docker logs "$container"
 done

--- a/test/docker_logs.sh
+++ b/test/docker_logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# run `docker logs` for all containers
+# Used in CI for outputing all logs when a run has failed
+set -e
+
+for container in $(docker ps --all | awk '{if(NR>1) print $NF}')
+do
+  echo "Container: $container"
+  docker logs $container
+done


### PR DESCRIPTION
This would help debug issues such as
https://github.com/wmde/wikibase-release-pipeline/pull/364
