### PR TITLE
Simplify test system set up docs

### DIFF
--- a/docs/topics/test-system.md
+++ b/docs/topics/test-system.md
@@ -54,106 +54,23 @@ sudo chown mediawiki:wikidev /opt/test-systems
 sudo chmod +775 /opt/test-systems
 ```
 
-You can create a test system using the parameterized bash code below.
-The inputs are:
+You can create a test system using the `prepare-docker-compose-config` script from https://github.com/wmde/wikibase-suite-test-system-tools which generates the necessary docker compose configuration using parametrized input. 
+The input paremeters are:
 
+ - IMAGE_PREFIX: Prefix of images to use. Use an empty string to use locally loaded images.
  - TEST_SYSTEM: The name of the test system to create, should be either "latest" or "previous"
  - EXAMPLE_HASH: Hash of the release pipeline repository to use the docker-compose example from
  - BUILD_NUMBER: Build of images, or tag, to use for images of the test system
 
-Do the following (with the parameters you require)...
+For example:
 
 ```sh
-# Inputs for setup
-IMAGE_PREFIX=ghcr.io/wmde/
+export IMAGE_PREFIX=ghcr.io/wmde/
+export TEST_SYSTEM=latest
+export EXAMPLE_HASH=53fd2bfa56085d43b1190371a8ed8c881643f4b8
+export BUILD_NUMBER=latest
 
-TEST_SYSTEM=latest
-EXAMPLE_HASH=53fd2bfa56085d43b1190371a8ed8c881643f4b8
-BUILD_NUMBER=latest
-
-#TEST_SYSTEM=fedprops
-#EXAMPLE_HASH=53fd2bfa56085d43b1190371a8ed8c881643f4b8
-#BUILD_NUMBER=3303724221
-
-#TEST_SYSTEM=fedprops-previous
-#EXAMPLE_HASH=53fd2bfa56085d43b1190371a8ed8c881643f4b8
-#BUILD_NUMBER=2971822356
-
-#TEST_SYSTEM=fedprops-previous
-#EXAMPLE_HASH=53fd2bfa56085d43b1190371a8ed8c881643f4b8
-#BUILD_NUMBER=2971822356
-
-# Calculate some things
-PORT_BASE="83"
-DOMAIN_SUFFIX=-$TEST_SYSTEM
-if [ "$TEST_SYSTEM" == "previous" ];
-then
-    PORT_BASE="82"
-fi
-if [ "$TEST_SYSTEM" == "latest" ];
-then
-    # Do not suffix domains on the latest system
-    DOMAIN_SUFFIX=""
-    PORT_BASE="83"
-fi
-if [ "$TEST_SYSTEM" == "fedprops-previous" ];
-then
-    PORT_BASE="84"
-fi
-if [ "$TEST_SYSTEM" == "fedprops" ];
-then
-    PORT_BASE="85"
-fi
-
-umask 002
-mkdir -p /opt/test-systems/$TEST_SYSTEM
-cd /opt/test-systems/$TEST_SYSTEM
-
-# Download the repo at the desired version, and extract the example
-wget https://github.com/wmde/wikibase-release-pipeline/archive/$EXAMPLE_HASH.zip
-unzip $EXAMPLE_HASH.zip
-rm $EXAMPLE_HASH.zip
-cp -r ./wikibase-release-pipeline-$EXAMPLE_HASH/example/* .
-rm -rf ./wikibase-release-pipeline-$EXAMPLE_HASH
-
-# Create a .env file
-cp ./template.env ./.env
-echo "# Test system customizations" >> ./.env
-# Default settings to change
-echo "MW_WG_ENABLE_UPLOADS=true" >> ./.env
-# Public facing domains
-echo "WIKIBASE_HOST=wikibase-product-testing$DOMAIN_SUFFIX.wmflabs.org" >> ./.env
-echo "WDQS_FRONTEND_HOST=wikibase-query-testing$DOMAIN_SUFFIX.wmflabs.org" >> ./.env
-echo "QUICKSTATEMENTS_HOST=wikibase-qs-testing$DOMAIN_SUFFIX.wmflabs.org" >> ./.env
-# Images to use
-echo "WIKIBASE_IMAGE_NAME=${IMAGE_PREFIX}wikibase:$BUILD_NUMBER" >> ./.env
-echo "WDQS_IMAGE_NAME=${IMAGE_PREFIX}wdqs:$BUILD_NUMBER" >> ./.env
-echo "WDQS_FRONTEND_IMAGE_NAME=${IMAGE_PREFIX}wdqs-frontend:$BUILD_NUMBER" >> ./.env
-echo "ELASTICSEARCH_IMAGE_NAME=${IMAGE_PREFIX}elasticsearch:$BUILD_NUMBER" >> ./.env
-echo "WIKIBASE_BUNDLE_IMAGE_NAME=${IMAGE_PREFIX}wikibase-bundle:$BUILD_NUMBER" >> ./.env
-echo "QUICKSTATEMENTS_IMAGE_NAME=${IMAGE_PREFIX}quickstatements:$BUILD_NUMBER" >> ./.env
-echo "WDQS_PROXY_IMAGE_NAME=${IMAGE_PREFIX}wdqs-proxy:$BUILD_NUMBER" >> ./.env
-# Ports to expose
-echo "WIKIBASE_PORT=${PORT_BASE}80" >> ./.env
-echo "WDQS_FRONTEND_PORT=${PORT_BASE}81" >> ./.env
-echo "QS_PUBLIC_SCHEME_HOST_AND_PORT=https://wikibase-qs-testing$DOMAIN_SUFFIX.wmcloud.org" >> ./.env
-echo "WB_PUBLIC_SCHEME_HOST_AND_PORT=https://wikibase-product-testing$DOMAIN_SUFFIX.wmcloud.org" >> ./.env
-echo "QUICKSTATEMENTS_PORT=${PORT_BASE}82" >> ./.env
-
-# Modify the quickstatements WB_PUBLIC_SCHEME_HOST_AND_PORT in the example
-# TODO if this works for the test system, push this to the real example...
-sed -i 's/WB_PUBLIC_SCHEME_HOST_AND_PORT=http:\/\/${WIKIBASE_HOST}:${WIKIBASE_PORT}/WB_PUBLIC_SCHEME_HOST_AND_PORT=${WB_PUBLIC_SCHEME_HOST_AND_PORT}/' ./docker-compose.extra.yml
-
-# Create an extra LocalSettings.php file to load
-wget https://gist.githubusercontent.com/addshore/760b770427eb81d4d1ee14eb331246ea/raw/e0854a6593ca40afecab69ed1aa437b40cae53ba/extra-localsettings.txt
-mv extra-localsettings.txt ./extra.LocalSettings.php
-sed -i 's/#- .\/LocalSettings.php:\/var\/www\/html\/LocalSettings.d\/LocalSettings.override.php/- .\/extra.LocalSettings.php:\/var\/www\/html\/LocalSettings.d\/LocalSettings.extra.php/' ./docker-compose.yml
-
-if [[ "$TEST_SYSTEM" == *"fedprop"* ]]; then
-  echo "Configuring federated properties"
-  wget https://gist.githubusercontent.com/addshore/760b770427eb81d4d1ee14eb331246ea/raw/e0854a6593ca40afecab69ed1aa437b40cae53ba/extra-localsettings-fedprops.txt
-  cat extra-localsettings-fedprops.txt >> ./extra.LocalSettings.php
-fi
+../prepare-docker-compose-config.sh
 ```
 
 To start the test system:


### PR DESCRIPTION
By recommending to use a bash script instead of manually typing 50+ lines of shell commands