### PR TITLE
T341472: use /usr/bin/env in shebang

### DIFF
--- a/Docker/build/WDQS/entrypoint.sh
+++ b/Docker/build/WDQS/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file is provided by the wikibase/wdqs docker image.
 
 # Test if required environment variables have been set

--- a/Docker/build/Wikibase/entrypoint.sh
+++ b/Docker/build/Wikibase/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file is provided by the wikibase/wikibase docker image.
 
 # Test if required environment variables have been set

--- a/Docker/build/WikibaseBundle/extra-install/ElasticSearch.sh
+++ b/Docker/build/WikibaseBundle/extra-install/ElasticSearch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 if [ -z "$MW_ELASTIC_HOST" ] || \

--- a/Docker/build/WikibaseBundle/extra-install/QuickStatements.sh
+++ b/Docker/build/WikibaseBundle/extra-install/QuickStatements.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 php /var/www/html/extensions/OAuth/maintenance/createOAuthConsumer.php \

--- a/Docker/publish/upload_dockerhub/publish.sh
+++ b/Docker/publish/upload_dockerhub/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ -z "$WDQS_DOCKER_PATH" ] || \

--- a/Docker/publish/upload_tar/publish.sh
+++ b/Docker/publish/upload_tar/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ -z "$RELEASE_HOST" ] || \

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TARGET=$1
 RELEASE_ENV_FILE=$2
 

--- a/build/build_elasticsearch_docker.sh
+++ b/build/build_elasticsearch_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "Building elasticseach $ELASTICSEARCH_VERSION"

--- a/build/build_extension.sh
+++ b/build/build_extension.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ROOT="$(pwd)"

--- a/build/build_quickstatements.sh
+++ b/build/build_quickstatements.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ROOT="$(pwd)"

--- a/build/build_quickstatements_docker.sh
+++ b/build/build_quickstatements_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 mkdir -p Docker/build/QuickStatements/artifacts

--- a/build/build_wdqs.sh
+++ b/build/build_wdqs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build script for WDQS
 # Downloads the service-dist.tar file from archiva and caches it 
 set -e

--- a/build/build_wdqs_docker.sh
+++ b/build/build_wdqs_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SERVICE_DIST_TAR="$TARBALL_PATH"

--- a/build/build_wdqs_frontend.sh
+++ b/build/build_wdqs_frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 ROOT="$(pwd)"

--- a/build/build_wdqs_proxy_docker.sh
+++ b/build/build_wdqs_proxy_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 docker build \

--- a/build/build_wikibase.sh
+++ b/build/build_wikibase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 ROOT="$(pwd)"

--- a/build/build_wikibase_bundle_docker.sh
+++ b/build/build_wikibase_bundle_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1090
 set -e
 

--- a/build/build_wikibase_docker.sh
+++ b/build/build_wikibase_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1091
 set -e
 

--- a/build/clean_repo.sh
+++ b/build/clean_repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Cleans repository of undesired files
 set -ex
 

--- a/build/clone_repo.sh
+++ b/build/clone_repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Clones a repository and writes the metadata file
 set -e
 

--- a/build/external_extension/WikibaseEdtf.sh
+++ b/build/external_extension/WikibaseEdtf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ## WikibaseEDTF

--- a/build/external_extension/WikibaseLocalMedia.sh
+++ b/build/external_extension/WikibaseLocalMedia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ## WikibaseLocalMedia

--- a/diagrams/build.sh
+++ b/diagrams/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Build dynamic overview
 TMP_FILE="$(mktemp -d)/input.mmd"

--- a/example/extra-install.sh
+++ b/example/extra-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 # Enables and configures elasticsearch index

--- a/example/jobrunner-entrypoint.sh
+++ b/example/jobrunner-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Originally inspired by Brennen Bearnes jobrunner entrypoint
 # https://gerrit.wikimedia.org/r/plugins/gitiles/releng/dev-images/+/refs/heads/master/common/jobrunner/entrypoint.sh

--- a/publish/dockerhub.sh
+++ b/publish/dockerhub.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd publish

--- a/publish/download.sh
+++ b/publish/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd publish

--- a/publish/tar-nodocker.sh
+++ b/publish/tar-nodocker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ -z "$RELEASE_HOST" ] || \

--- a/publish/tar.sh
+++ b/publish/tar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd publish

--- a/test/config/client/wikibase/extra-install-client.sh
+++ b/test/config/client/wikibase/extra-install-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install extra things for client-repo relationship
 set -ex
 

--- a/test/config/client/wikibase/extra-install-repo.sh
+++ b/test/config/client/wikibase/extra-install-repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install extra things for client-repo relationship
 set -ex
 

--- a/test/config/repo/wikibase/run-jobs.sh
+++ b/test/config/repo/wikibase/run-jobs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install extra things for repo
 set -ex
 

--- a/test/docker_logs.sh
+++ b/test/docker_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run `docker logs` for all containers
 # Used in CI for outputing all logs when a run has failed
 set -e

--- a/test/run_selenium.sh
+++ b/test/run_selenium.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2086
 set -e
 

--- a/test/suite-config/elasticsearch/wikibase/extra-install.sh
+++ b/test/suite-config/elasticsearch/wikibase/extra-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 bash /extra-install/ElasticSearch.sh

--- a/test/suite-config/quickstatements/wikibase/extra-install.sh
+++ b/test/suite-config/quickstatements/wikibase/extra-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 bash /extra-install/QuickStatements.sh

--- a/test/test_example.sh
+++ b/test/test_example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1091,SC1090
 set -e
 

--- a/test/test_stop.sh
+++ b/test/test_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1091,SC2086,SC2046
 set -e
 

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd test

--- a/test/test_upgrade.sh
+++ b/test/test_upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1091,SC1090,SC2086
 set -e
 

--- a/update_cache.sh
+++ b/update_cache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 function clone_if_not_present {


### PR DESCRIPTION
Until now, scripts hardcoded the path to bash in the shebang line, rendering the scripts unable to execute on systems where bash does not live in /bin/bash (e.g. NixOS). This change introduces the use of env(1) in shebangs in order to lookup bash in the current environment.