### PR TITLE
T341222: extend gzip compression rate usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@ For [testing](docs/topics/testing.md), you can use `test`, `test-all` make targe
 ## Documentation
 
 The pipeline documentation can be found [here](docs/index.md).
-

--- a/build/build_elasticsearch_docker.sh
+++ b/build/build_elasticsearch_docker.sh
@@ -7,4 +7,4 @@ docker build \
     --build-arg=ELASTICSEARCH_PLUGIN_EXTRA_VERSION="$ELASTICSEARCH_PLUGIN_EXTRA_VERSION" \
     Docker/build/Elasticsearch/ -t "$1"
 
-docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE"f > "$(pwd)"/artifacts/elasticsearch.docker.tar.gz
+docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE" > "$(pwd)"/artifacts/elasticsearch.docker.tar.gz

--- a/build/build_quickstatements.sh
+++ b/build/build_quickstatements.sh
@@ -17,7 +17,7 @@ UPDATE_SUBMODULE=0 bash "$ROOT"/build/clone_repo.sh "$MAGNUSTOOLS_COMMIT_HASH" "
 bash "$ROOT"/build/clean_repo.sh "$MAGNUSTOOLS_GIT_DIR"
 
 cd "$TEMP_GIT_DIR"
-GZIP=-9 tar -C "$TEMP_GIT_DIR" -zcvf "$TARBALL_PATH" magnustools quickstatements
+tar -C "$TEMP_GIT_DIR" -cvf - magnustools quickstatements | gzip -"$GZIP_COMPRESSION_RATE" > "$TARBALL_PATH"
 cd -
 
 if [ -n "$GITHUB_ENV" ]; then

--- a/build/build_quickstatements_docker.sh
+++ b/build/build_quickstatements_docker.sh
@@ -9,4 +9,4 @@ docker build \
     --build-arg COMPOSER_IMAGE_VERSION="$COMPOSER_IMAGE_VERSION" \
     --no-cache Docker/build/QuickStatements/ -t "$1"
 
-docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE"f > artifacts/"$1".docker.tar.gz
+docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE" > artifacts/"$1".docker.tar.gz

--- a/build/build_wdqs_docker.sh
+++ b/build/build_wdqs_docker.sh
@@ -8,4 +8,4 @@ cp Docker/build/wait-for-it.sh Docker/build/WDQS/
 
 docker build --pull --build-arg tarball="$(basename "$SERVICE_DIST_TAR")" Docker/build/WDQS/ -t "$1"
 
-docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE"f > artifacts/"$1".docker.tar.gz
+docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE" > artifacts/"$1".docker.tar.gz

--- a/build/build_wdqs_frontend.sh
+++ b/build/build_wdqs_frontend.sh
@@ -15,8 +15,7 @@ UPDATE_SUBMODULE=1 bash "$ROOT"/build/clone_repo.sh \
 bash "$ROOT"/build/clean_repo.sh "$WDQS_FRONTEND_GIT_DIR"
 
 cd "$WDQS_FRONTEND_GIT_DIR"
-GZIP=-9 tar -zcvf "$TARBALL_PATH" -- *
-
+tar -cvf - -- * | gzip -"$GZIP_COMPRESSION_RATE" > "$TARBALL_PATH" 
 cd "$ROOT"
 
 if [ -n "$GITHUB_ENV" ]; then

--- a/build/build_wdqs_proxy_docker.sh
+++ b/build/build_wdqs_proxy_docker.sh
@@ -4,4 +4,4 @@ set -ex
 docker build \
     Docker/build/WDQS-proxy/ -t "$1"
 
-docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE"f > artifacts/"$1".docker.tar.gz
+docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE" > artifacts/"$1".docker.tar.gz

--- a/build/build_wikibase.sh
+++ b/build/build_wikibase.sh
@@ -38,7 +38,7 @@ docker run \
     install --no-dev --ignore-platform-reqs -vv -d "/tmp/Wikibase"
 chmod 755 "$COMPOSER_VENDOR"
 
-GZIP=-9 tar -C "$TEMP_GIT_DIR" -zcf "$TEMP_TAR_DIR"/Wikibase.tar.gz Wikibase
+tar -C "$TEMP_GIT_DIR" -cf - Wikibase | gzip -"$GZIP_COMPRESSION_RATE" > "$TEMP_TAR_DIR"/Wikibase.tar.gz
 
 TARBALL_PATH="$TEMP_TAR_DIR/Wikibase.tar.gz"
 

--- a/build/build_wikibase_bundle_docker.sh
+++ b/build/build_wikibase_bundle_docker.sh
@@ -54,4 +54,4 @@ docker build --no-cache \
     --build-arg COMPOSER_IMAGE_VERSION="$COMPOSER_IMAGE_VERSION" \
     Docker/build/WikibaseBundle/ -t "$WIKIBASE_BUNDLE_IMAGE_NAME"
 
-docker save "$WIKIBASE_BUNDLE_IMAGE_NAME" | gzip -"$GZIP_COMPRESSION_RATE"f > artifacts/"$WIKIBASE_BUNDLE_IMAGE_NAME".docker.tar.gz
+docker save "$WIKIBASE_BUNDLE_IMAGE_NAME" | gzip -"$GZIP_COMPRESSION_RATE" > artifacts/"$WIKIBASE_BUNDLE_IMAGE_NAME".docker.tar.gz

--- a/build/build_wikibase_docker.sh
+++ b/build/build_wikibase_docker.sh
@@ -30,4 +30,4 @@ docker build \
     \
     Docker/build/Wikibase/ -t "$1"
 
-docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE"f > artifacts/"$1".docker.tar.gz
+docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE" > artifacts/"$1".docker.tar.gz


### PR DESCRIPTION
The release pipeline has a setting called GZIP_COMPRESSION_RATE that can be set in local.env. Using this setting gzip invocations are configured. The user can choose the compression rate/speed tradeoff. 1 being fast and weak compression, 9 being slow and strong compression. This change extends the usage of this configuration value to the remaining gzip invocations as well as fixes the handing over of the actual value to gzip by removing the extra 'f' (not required or supported according to man gzip(1)).