### PR TITLE
fix: Chromium install in ARM (Mac M1) build environments

### DIFF
--- a/build/build_wdqs_frontend_docker.sh
+++ b/build/build_wdqs_frontend_docker.sh
@@ -2,6 +2,6 @@
 set -e
 
 cp -r "$TARBALL_PATH" Docker/build/WDQS-frontend
-docker build --pull --build-arg tarball="$(basename "$TARBALL_PATH")" Docker/build/WDQS-frontend/ -t "$1"
+docker build --platform=linux/amd64 --pull --build-arg tarball="$(basename "$TARBALL_PATH")" Docker/build/WDQS-frontend/ -t "$1"
 
 docker save "$1" | gzip -"$GZIP_COMPRESSION_RATE"f > "$(pwd)"/artifacts/"$1".docker.tar.gz


### PR DESCRIPTION
Pin platform to amd64 for WDQS. Fixes issue particular to ARM / Mac M1 environment by making explicit the `platform=linux/amd64`for the WDQS Docker container which otherwise will fail in trying to find and install an ARM-based version of Chromium. 