### PR TITLE
T341654: git/docker ignore mwlog folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ cache/*
 git_cache/*
 Docker/**/*.tar.gz
 test/log
+test/mwlog
 diagrams/node_modules/
 artifacts/*
 docs/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Docker/build/WDQS/wait-for-it.sh
 #temp 
 Docker/**/*.tar.gz
 test/log
+test/mwlog
 diagrams/node_modules/
 artifacts/*
 local.env


### PR DESCRIPTION
It should not be commited nor put into image builds.