### PR TITLE
T334778: wmde12 security release for mw 1.38.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,16 +4,17 @@ This file is only intended to serve the developers of this repository and of the
 
 This provides an overview of the releases that have been made using this release pipeline.
 
-## Work In Progress - April: 2023: Security releases for 1.38.6
+## Work In Progress - July 2023: Security releases for 1.38.7
 
-- [MediaWiki security release announcement](https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/message/6UQBHI5FWLATD7QO7DI4YS54U7XSSLAN/)
+- [MediaWiki security and maintenance release announcement: 1.35.10 / 1.38.6 / 1.39.3](https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/message/6UQBHI5FWLATD7QO7DI4YS54U7XSSLAN/)
+- [MediaWiki security and maintenance release announcement: 1.35.11 / 1.38.7 / 1.39.4](https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/thread/HVT3U3XYY35PSCIQPHMY4VQNF3Q6MHUO/)
 - [MediaWiki full release notes](https://www.mediawiki.org/wiki/Release_notes/1.38)
 
 | Suite Version | MediaWiki release | Date available | Run number | Release task  |
 |---------------|----------------------|----------------|------------| --------------|
-| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 7.3.19+), WDQS (0.3.118) | April 2023 | ??? | [T334778](https://phabricator.wikimedia.org/T334778) |
+| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 7.3.19+), WDQS (0.3.118) | July 2023         | ??? | [T334778](https://phabricator.wikimedia.org/T334778) |
 
-## March: 2023: First 1.39 release
+## March 2023: First 1.39 release
 
 The [standard MediaWiki upgrade process](https://www.mediawiki.org/wiki/Manual:Upgrading) can be followed for this release.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This file is only intended to serve the developers of this repository and of the
 
 This provides an overview of the releases that have been made using this release pipeline.
 
-## Work In Progress - July 2023: Security releases for 1.38.7
+## Work In Progress - August 2023: Security releases for 1.38.7
 
 - [MediaWiki security and maintenance release announcement: 1.35.10 / 1.38.6 / 1.39.3](https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/message/6UQBHI5FWLATD7QO7DI4YS54U7XSSLAN/)
 - [MediaWiki security and maintenance release announcement: 1.35.11 / 1.38.7 / 1.39.4](https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/thread/HVT3U3XYY35PSCIQPHMY4VQNF3Q6MHUO/)
@@ -12,7 +12,7 @@ This provides an overview of the releases that have been made using this release
 
 | Suite Version | MediaWiki release                                                       | Date available | Run number     | Release task  |
 |---------------|-------------------------------------------------------------------------|----------------|----------------| --------------|
-| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 8.0.29, debian/apache2 2.4.56-1~deb11u2), WDQS (0.3.118) | July 2023         | [5447147654](https://github.com/wmde/wikibase-release-pipeline/actions/runs/5456881917) | [T334778](https://phabricator.wikimedia.org/T334778) |
+| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 8.0.29, debian/apache2 2.4.56-1~deb11u2), WDQS (0.3.118) | August 2023         | [5447147654](https://github.com/wmde/wikibase-release-pipeline/actions/runs/5456881917) | [T334778](https://phabricator.wikimedia.org/T334778) |
 
 ## March 2023: First 1.39 release
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ This provides an overview of the releases that have been made using this release
 
 | Suite Version | MediaWiki release                                                       | Date available | Run number     | Release task  |
 |---------------|-------------------------------------------------------------------------|----------------|----------------| --------------|
-| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 8.0.29, debian/apache2 2.4.56-1~deb11u2), WDQS (0.3.118) | July 2023         | [5447147654](https://github.com/wmde/wikibase-release-pipeline/actions/runs/5447147654) | [T334778](https://phabricator.wikimedia.org/T334778) |
+| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 8.0.29, debian/apache2 2.4.56-1~deb11u2), WDQS (0.3.118) | July 2023         | [5447147654](https://github.com/wmde/wikibase-release-pipeline/actions/runs/5456881917) | [T334778](https://phabricator.wikimedia.org/T334778) |
 
 ## March 2023: First 1.39 release
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,9 @@ This provides an overview of the releases that have been made using this release
 - [MediaWiki security and maintenance release announcement: 1.35.11 / 1.38.7 / 1.39.4](https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/thread/HVT3U3XYY35PSCIQPHMY4VQNF3Q6MHUO/)
 - [MediaWiki full release notes](https://www.mediawiki.org/wiki/Release_notes/1.38)
 
-| Suite Version | MediaWiki release | Date available | Run number | Release task  |
-|---------------|----------------------|----------------|------------| --------------|
-| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 7.3.19+), WDQS (0.3.118) | July 2023         | ??? | [T334778](https://phabricator.wikimedia.org/T334778) |
+| Suite Version | MediaWiki release                                                       | Date available | Run number     | Release task  |
+|---------------|-------------------------------------------------------------------------|----------------|----------------| --------------|
+| wmde.12 ([spec](https://github.com/wmde/wikibase-release-pipeline/blob/wmde.12/versions/wmde12.env),[metadata](https://github.com/wmde/wikibase-release-pipeline/blob/main/versions/wmde12)) | MediaWiki (1.38.6, PHP 8.0.29, debian/apache2 2.4.56-1~deb11u2), WDQS (0.3.118) | July 2023         | [5447147654](https://github.com/wmde/wikibase-release-pipeline/actions/runs/5447147654) | [T334778](https://phabricator.wikimedia.org/T334778) |
 
 ## March 2023: First 1.39 release
 

--- a/versions/wmde12.env
+++ b/versions/wmde12.env
@@ -20,10 +20,10 @@ BUNDLE_EXT_EXTENSIONS=WikibaseLocalMedia,WikibaseEdtf
 BUNDLE_WMF_EXTENSIONS=Babel,cldr,CirrusSearch,ConfirmEdit,Elastica,EntitySchema,Nuke,OAuth,Scribunto,SyntaxHighlight_GeSHi,UniversalLanguageSelector,VisualEditor,WikibaseCirrusSearch,WikibaseManifest
 
 MEDIAWIKI_MAJOR_VERSION=1.38
-MEDIAWIKI_VERSION=1.38.6
+MEDIAWIKI_VERSION=1.38.7
 
 RELEASE_MAJOR_VERSION=1.38
-RELEASE_VERSION=1.38.6
+RELEASE_VERSION=1.38.7
 
 # MediaWiki 1.33.x - 1.38.x require Elasticsearch 6.5.x - 6.8.x. (6.8.23+ recommended)
 # https://www.mediawiki.org/wiki/Extension:CirrusSearch


### PR DESCRIPTION
Changing env variables and release docs to accommodate to mw1.38.7