### PR TITLE
T343802 - Add local linting script and run before each test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,23 @@ lint:
 
 .PHONY: test
 test: test-stop
+ifndef GITHUB_ACTIONS
 	@make lint
+endif
 	bash test/test_suite.sh ${SUITE}
 
 .PHONY: test-upgrade
 test-upgrade: upgrade-stop
+ifndef GITHUB_ACTIONS
 	@make lint
+endif
 	bash test/test_upgrade.sh ${VERSION} ${TO_VERSION}
 
 .PHONY: test-example
 test-example: example-stop
+ifndef GITHUB_ACTIONS
 	@make lint
+endif
 	bash test/test_example.sh ${SUITE}
 
 .PHONY: test-stop
@@ -41,7 +47,9 @@ example-stop:
 	make test-stop ARGS_CONFIG="--env-file ../example/template.env -f ../example/docker-compose.yml -f ../example/docker-compose.extra.yml"
 
 test-all:
+ifndef GITHUB_ACTIONS
 	@make lint
+endif
 
 	# bundle tests
 	bash test/test_suite.sh repo

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,23 @@ export
 download:
 	bash publish/download.sh
 
+.PHONY: lint
+lint:
+	@bash lint.sh
+
 .PHONY: test
 test: test-stop
+	@make lint
 	bash test/test_suite.sh ${SUITE}
 
 .PHONY: test-upgrade
 test-upgrade: upgrade-stop
+	@make lint
 	bash test/test_upgrade.sh ${VERSION} ${TO_VERSION}
 
 .PHONY: test-example
 test-example: example-stop
+	@make lint
 	bash test/test_example.sh ${SUITE}
 
 .PHONY: test-stop
@@ -34,6 +41,8 @@ example-stop:
 	make test-stop ARGS_CONFIG="--env-file ../example/template.env -f ../example/docker-compose.yml -f ../example/docker-compose.extra.yml"
 
 test-all:
+	@make lint
+
 	# bundle tests
 	bash test/test_suite.sh repo
 	bash test/test_suite.sh fedprops

--- a/lint.sh
+++ b/lint.sh
@@ -9,13 +9,13 @@ docker run --rm -v "$(pwd)":/code -v ./.hadolint.yml:/.hadolint.yml hadolint/had
 # Bash Script linting with Spellcheck (bash)
 # https://github.com/koalaman/shellcheck#from-your-terminal
 echo "✳️  Linting Shell Scripts (*.sh)"
-find . -type d -name node_modules -prune -false -o -name "*.sh" -print0 | xargs -0 docker run -v "$(pwd)":/code dcycle/shell-lint:2
+find . -type d -name node_modules -prune -false -o -name "*.sh" -print0 | xargs -0 docker run --rm -v "$(pwd)":/code dcycle/shell-lint:2
 
 # Javascript linting Selenium tests
 echo "✳️  Linting Javascript in Selenium specs (Docker/test/selenium/specs/**/.js)"
 {
   cd Docker/test/selenium
-  npm install
+  npm install --loglevel=error
 } > /dev/null || exit
 npm run lint --silent
 cd ../../..  > /dev/null || exit
@@ -24,7 +24,7 @@ cd ../../..  > /dev/null || exit
 echo "✳️  Linting Javascript in Diagrams code (diagrams/**/.js)"
 {
   cd diagrams
-  npm install  > /dev/null || exit
+  npm install  --loglevel=error > /dev/null || exit
 } > /dev/null || exit
 npm run lint --silent
 cd ..  > /dev/null || exit

--- a/lint.sh
+++ b/lint.sh
@@ -3,16 +3,16 @@
 # Dockerfile linting with Hadolint (uses rules from `.hadolint`)
 # https://github.com/hadolint/hadolint
 # -type d -name node_modules -prune
-echo "✳️  Linting Dockerfiles (**/Dockerfile)"
+echo "ℹ️  Linting Dockerfiles (**/Dockerfile)"
 docker run --rm -v "$(pwd)":/code -v ./.hadolint.yml:/.hadolint.yml hadolint/hadolint:latest-alpine sh -c "find /code -type f -name 'Dockerfile' | xargs hadolint"
 
 # Bash Script linting with Spellcheck (bash)
 # https://github.com/koalaman/shellcheck#from-your-terminal
-echo "✳️  Linting Shell Scripts (*.sh)"
+echo "ℹ️  Linting Shell Scripts (*.sh)"
 find . -type d -name node_modules -prune -false -o -name "*.sh" -print0 | xargs -0 docker run --rm -v "$(pwd)":/code dcycle/shell-lint:2
 
 # Javascript linting Selenium tests
-echo "✳️  Linting Javascript in Selenium specs (Docker/test/selenium/specs/**/.js)"
+echo "ℹ️  Linting Javascript in Selenium specs (Docker/test/selenium/specs/**/.js)"
 {
   cd Docker/test/selenium
   npm install --loglevel=error
@@ -21,7 +21,7 @@ npm run lint --silent
 cd ../../..  > /dev/null || exit
 
 # Javascript linting Diagrams code
-echo "✳️  Linting Javascript in Diagrams code (diagrams/**/.js)"
+echo "ℹ️  Linting Javascript in Diagrams code (diagrams/**/.js)"
 {
   cd diagrams
   npm install  --loglevel=error > /dev/null || exit

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Dockerfile linting with Hadolint (uses rules from `.hadolint`)
+# https://github.com/hadolint/hadolint
+# -type d -name node_modules -prune
+echo "✳️  Linting Dockerfiles (**/Dockerfile)"
+docker run --rm -v "$(pwd)":/code -v ./.hadolint.yml:/.hadolint.yml hadolint/hadolint:latest-alpine sh -c "find /code -type f -name 'Dockerfile' | xargs hadolint"
+
+# Bash Script linting with Spellcheck (bash)
+# https://github.com/koalaman/shellcheck#from-your-terminal
+echo "✳️  Linting Shell Scripts (*.sh)"
+find . -type d -name node_modules -prune -false -o -name "*.sh" -print0 | xargs -0 docker run -v "$(pwd)":/code dcycle/shell-lint:2
+
+# Javascript linting Selenium tests
+echo "✳️  Linting Javascript in Selenium specs (Docker/test/selenium/specs/**/.js)"
+{
+  cd Docker/test/selenium
+  npm install
+} > /dev/null || exit
+npm run lint --silent
+cd ../../..  > /dev/null || exit
+
+# Javascript linting Diagrams code
+echo "✳️  Linting Javascript in Diagrams code (diagrams/**/.js)"
+{
+  cd diagrams
+  npm install  > /dev/null || exit
+} > /dev/null || exit
+npm run lint --silent
+cd ..  > /dev/null || exit

--- a/lint.sh
+++ b/lint.sh
@@ -24,7 +24,7 @@ cd ../../..  > /dev/null || exit
 echo "ℹ️  Linting Javascript in Diagrams code (diagrams/**/.js)"
 {
   cd diagrams
-  npm install  --loglevel=error > /dev/null || exit
+  npm install  --loglevel=error
 } > /dev/null || exit
 npm run lint --silent
 cd ..  > /dev/null || exit


### PR DESCRIPTION
https://phabricator.wikimedia.org/T343802

- Makes project-wide linking available in local dev for using `make lint`, which does lints what our current Github lint action does, i.e.:
  -  JavaScript in `Docker/test/selenium` and `diagrams` with ESLint
  - `Dockerfile`s everywhere with hadolint
  - `*.sh` with Spellchecker

- Runs linting before each test run (except when ran within a `GITHUB_ACTION`)
- DOES NOT add linting as a Github pre-commit hook, this is an area for possible follow-up another time
- DOES NOT re-use this shell script as the Github Action linting, and this too should be considered at some point to keep our CI more like our local dev environment