### PR TITLE
TEMP: Test GitHub action test naming

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -505,7 +505,7 @@ jobs:
           base__repo_client,
           base__pingback,
           base__fedprops,
-        ],
+        ]
         databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
     needs:
       - build_wikibase_bundle

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -492,7 +492,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
+        # databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
         suite: [ 
           repo, 
           fedprops,

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -492,7 +492,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
         suite: [ 
           repo, 
           fedprops,
@@ -506,7 +505,8 @@ jobs:
           base__repo_client,
           base__pingback,
           base__fedprops,
-        ]
+        ],
+        databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
     needs:
       - build_wikibase_bundle
       - build_wdqs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,4 +61,3 @@ jobs:
         run: |
           cd diagrams
           node make_overview.js
-          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
+        # databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
         suite: [
           repo,
           fedprops,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           base__repo_client,
           base__pingback,
           base__fedprops,
-        ],
+        ]
         databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
         suite: [
           repo,
           fedprops,
@@ -31,7 +30,8 @@ jobs:
           base__repo_client,
           base__pingback,
           base__fedprops,
-        ]
+        ],
+        databaseImageName: [ 'mariadb:10.9' ] # 'mysql:5.6' disabled https://phabricator.wikimedia.org/T296066
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,7 +16,7 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 2 --max-time 10 --retry-max-time 120 "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 2 --max-time 10 --retry-max-time 120 --output /dev/null --silent "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,8 +16,7 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        # if ! (/usr/bin/curl --fail --retry 240 --retry-all-errors --retry-delay 1 --max-time 600 --retry-max-time 600 --output /dev/null --silent "$FULL_URL";) then
-        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 120 "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 2 --max-time 10 --retry-max-time 120 "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,7 +16,8 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        if ! (/usr/bin/curl --fail --retry 240 --retry-all-errors --retry-delay 1 --max-time 600 --retry-max-time 600 --output /dev/null --silent "$FULL_URL";) then
+        # if ! (/usr/bin/curl --fail --retry 240 --retry-all-errors --retry-delay 1 --max-time 600 --retry-max-time 600 --output /dev/null --silent "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 120 "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,7 +16,7 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 240 --output /dev/null --silent "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 240 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 240 --output /dev/null --silent "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,7 +16,7 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 600 --retry-max-time 120 --output /dev/null --silent "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 240 --retry-all-errors --retry-delay 1 --max-time 600 --retry-max-time 600 --output /dev/null --silent "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,7 +16,7 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 120 --output /dev/null --silent "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 600 --retry-max-time 120 --output /dev/null --silent "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi

--- a/Docker/test/setup/test_curl.sh
+++ b/Docker/test/setup/test_curl.sh
@@ -16,7 +16,7 @@ check_if_up() {
     if ! (/usr/bin/curl --fail --output /dev/null --silent "$FULL_URL";) then
         echo "🔄 Waiting for $DISPLAY_URL"
 
-        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 2 --max-time 10 --retry-max-time 120 --output /dev/null --silent "$FULL_URL";) then
+        if ! (/usr/bin/curl --fail --retry 120 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 240 --output /dev/null --silent "$FULL_URL";) then
             echo "❌ Could not load $DISPLAY_URL"
             exit 1
         fi


### PR DESCRIPTION
Fixes Github Actions test runs issues:

- Increases `check_if_up` `curl` time between retries to 2 seconds from 1, effectively increasing timeout to ~240 seconds from ~120 seconds (which often wasn't enough for slower Github Action job runners to get Wikibase up)
- Renames Github Action test runs to `test_wikibase (repo, mariadb...)` from `test_wikibase (mariadb..., repo)` making it easy to see the name of the test suite ran in the summary results here on Github.