### PR TITLE
T343348  (2) - Further Reorg Work

### DIFF
--- a/.github/reporter/report.js
+++ b/.github/reporter/report.js
@@ -7,7 +7,7 @@ if( !process.env.SUITE ) {
     return;
 }
 
-const filePath = `../log/${process.env.SUITE}/result.json`;
+const filePath = `../../test/suite-config/${process.env.SUITE}/logs/result.json`;
 
 var resultObject = {};
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Docker/build/WDQS/wait-for-it.sh
 
 #temp 
 Docker/**/*.tar.gz
+test/suite-config/*/logs/
 test/log
 test/mwlog
 docs/diagrams/node_modules/

--- a/test/test_example.sh
+++ b/test/test_example.sh
@@ -13,7 +13,7 @@ cd test
 set -o allexport; source ../example/template.env; source example.env; set +o allexport
 
 # log directory setup
-export LOG_DIR="log/$SUITE"
+export LOG_DIR="suite-config/$SUITE/logs"
 export TEST_LOG="$LOG_DIR/$SUITE.log"
 
 rm -f "$TEST_LOG" || true

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -11,7 +11,7 @@ if [ -z "$SUITE" ]; then
 fi
 
 # log directory setup
-export LOG_DIR="log/$SUITE"
+export LOG_DIR="suite-config/$SUITE/logs"
 export TEST_LOG="$LOG_DIR/$SUITE.log"
 
 rm -f "$TEST_LOG" || true

--- a/test/test_upgrade.sh
+++ b/test/test_upgrade.sh
@@ -26,7 +26,7 @@ DEFAULT_SUITE_CONFIG="-f docker-compose.upgrade.yml"
 SUITE=upgrade
 
 # log directory setup
-export LOG_DIR="log/$SUITE"
+export LOG_DIR="suite-config/$SUITE/logs"
 export TEST_LOG="$LOG_DIR/$SUITE.log"
 
 rm -f "$TEST_LOG" || true
@@ -135,7 +135,7 @@ fi
 
 SUITE=post_upgrade
 
-LOG_DIR="log/$SUITE"
+LOG_DIR="suite-config/$SUITE/logs"
 TEST_LOG="$LOG_DIR/$SUITE.log"
 
 mkdir -p "$LOG_DIR"

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -11,7 +11,7 @@ const JsonReporter = require( './json-reporter.js' );
 const defaultFunctions = require( './helpers/default-functions.js' );
 const WikibaseApi = require( 'wdio-wikibase/wikibase.api' );
 
-const logPath = process.env.LOG_DIR || `${__dirname}/log/${process.env.SUITE}`;
+const logPath = process.env.LOG_DIR || `${__dirname}/suite-config/${process.env.SUITE}/logs`;
 const screenshotPath = `${logPath}/screenshots`;
 const resultFilePath = `${logPath}/result.json`;
 


### PR DESCRIPTION
- [ ] Move logs into test/suite-config/[SUITE]/logs
- [ ] ...


- [x]  Move test/docker-compose.upgrade.yml and test/docker-compose.upgrade.wdqs.yml into test/upgrade
- [x]  Move test/docker-compose.example.yml into test/suite/example
- [x]  Move Docker/test/selenium/specs/ to test/
- [ ]  Move test/suite-config/repo/* into test/repo (once above Selenium spec directory is moved to that location) TBD
- [ ]  Move some of what is now in test/suite-config root into suite directories allowing duplication, but keeping test suites more idempotent and explicit ?
- [ ] 