### PR TITLE
T344551: Don't load Elasticsearch extensions when Elasticsearch isn't present

### DIFF
--- a/Docker/build/WikibaseBundle/LocalSettings.d.template/CirrusSearch.php
+++ b/Docker/build/WikibaseBundle/LocalSettings.d.template/CirrusSearch.php
@@ -1,6 +1,8 @@
 <?php
 
-// https://www.mediawiki.org/wiki/Extension:CirrusSearch
-wfLoadExtension( 'CirrusSearch' );
+if ( getenv('MW_ELASTIC_HOST') !== false ) {
+  // https://www.mediawiki.org/wiki/Extension:CirrusSearch
+  wfLoadExtension( 'CirrusSearch' );
 
-// See WikibaseCirrusSearch.php for further configuration
+  // See WikibaseCirrusSearch.php for further configuration
+}

--- a/Docker/build/WikibaseBundle/LocalSettings.d.template/Elastica.php
+++ b/Docker/build/WikibaseBundle/LocalSettings.d.template/Elastica.php
@@ -1,6 +1,8 @@
 <?php
 
-// https://www.mediawiki.org/wiki/Extension:Elastica
-wfLoadExtension( 'Elastica' );
+if ( getenv('MW_ELASTIC_HOST') !== false ) {
+  // https://www.mediawiki.org/wiki/Extension:Elastica
+  wfLoadExtension( 'Elastica' );
 
-// See WikibaseCirrusSearch.php for further configuration
+  // See WikibaseCirrusSearch.php for further configuration
+}

--- a/Docker/build/WikibaseBundle/LocalSettings.d.template/WikibaseCirrusSearch.php
+++ b/Docker/build/WikibaseBundle/LocalSettings.d.template/WikibaseCirrusSearch.php
@@ -1,9 +1,9 @@
 <?php
 
-// https://www.mediawiki.org/wiki/Extension:WikibaseCirrusSearch
-wfLoadExtension( 'WikibaseCirrusSearch' );
-
 if ( getenv('MW_ELASTIC_HOST') !== false ) {
+    // https://www.mediawiki.org/wiki/Extension:WikibaseCirrusSearch
+    wfLoadExtension( 'WikibaseCirrusSearch' );
+
     $wgCirrusSearchServers = [ $_ENV['MW_ELASTIC_HOST'] ];
     $wgSearchType = 'CirrusSearch';
     $wgCirrusSearchExtraIndexSettings['index.mapping.total_fields.limit'] = 5000;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T344551