### PR TITLE
T343348 Fix: Results overwrite each other in TestArtifacts.zip from build_and_test Github Action output

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -552,7 +552,7 @@ jobs:
         if: always()
         with:
           name: TestArtifacts
-          path: test/suites/${{ matrix.suite }}/results
+          path: test/suites/**/results
 
   test_upgrade_base:
     timeout-minutes: 20


### PR DESCRIPTION
Issue found in QA of: https://github.com/wmde/wikibase-release-pipeline/pull/449. This resolves it.

Current output `TestArtifacts.zip` output of `main` from `_build_and_test` run in Github Actions:

<img width="285" alt="image" src="https://github.com/wmde/wikibase-release-pipeline/assets/6294/703fb152-6f67-4df9-aca2-c9fcf61805dc">

Expected output which this change generates:

<img width="334" alt="image" src="https://github.com/wmde/wikibase-release-pipeline/assets/6294/6eed5c64-cf13-4965-b5bc-0f9a22bc9e39">

