### PR TITLE
T343348 Fix: Test run status logging pointing to wrong path to test log file

### DIFF
--- a/test/suites/setup.sh
+++ b/test/suites/setup.sh
@@ -8,6 +8,6 @@ scripts/check_if_up.sh "$WDQS_FRONTEND_SERVER" "/"
 SUITE_SETUP_FILE="suites/$SUITE/setup.sh"
 
 if [ -f "$SUITE_SETUP_FILE" ]; then
-    echo "🔄 Running \"$SUITE_SETUP_FILE\"" 2>&1 | tee -a "$TEST_LOG"
+    echo "🔄 Running \"$SUITE_SETUP_FILE\"" 2>&1 | tee -a "../$TEST_LOG"
     $SUITE_SETUP_FILE
 fi


### PR DESCRIPTION
A very minor issue with the log file path in the case of a `test/suites/SUITE/setup.sh` existing. The status message that logs that it is using that file was not writing to log as the path was wrong. This fixes that.