### PR TITLE
fix(github-actions): GHCR upload

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -275,6 +275,7 @@ jobs:
   upload_ghcr:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # if: github.ref == 'refs/heads/main'
 
     needs:
       - test
@@ -300,14 +301,12 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        # if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store built docker image on GHCR
-        # if: github.ref == 'refs/heads/main'
         uses: wmde/tag-push-ghcr-action@v3
         with:
           image_name: "wikibase/${{ matrix.docker_image }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -284,9 +284,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
+        docker_image:
           [
             "wikibase",
+            "wikibase-bundle",
             "elasticsearch",
             "wdqs",
             "wdqs-frontend",
@@ -309,5 +310,5 @@ jobs:
         # if: github.ref == 'refs/heads/main'
         uses: wmde/tag-push-ghcr-action@v3
         with:
-          image_name: "wikibase/${{ inputs.name }}"
+          image_name: "wikibase/${{ matrix.docker_image }}"
           tag: ${{ github.run_id }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -322,5 +322,5 @@ jobs:
       - name: Store built docker image on GHCR
         uses: wmde/tag-push-ghcr-action@v3
         with:
-          image_name: "wikibase/${{ matrix.docker_image }}"
+          image_name: ${{ matrix.docker_image }}
           tag: ${{ github.run_id }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -275,7 +275,7 @@ jobs:
   upload_ghcr:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/mw-[0-9].[0-9][0-9]')
 
     needs:
       - test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -299,14 +299,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ inputs.github_token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store built docker image on GHCR
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         uses: wmde/tag-push-ghcr-action@v3
         with:
           image_name: "wikibase/${{ inputs.name }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -275,7 +275,7 @@ jobs:
   upload_ghcr:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/mw-[0-9].[0-9][0-9]')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/mw-')
 
     needs:
       - test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -299,6 +299,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get built Docker images
+        uses: actions/download-artifact@v3
+        with:
+          name: DockerImages
+          path: artifacts/
+
+      - name: Load docker images
+        shell: bash
+        run: |
+          for file in artifacts/*.docker.tar.gz; do     
+            docker load -i "$file"
+          done
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This PR fixes the broken GHCR upload on main.
 - load docker images from artifacts before pushing
 - fix auth variables
 - run on `main` and `mw-` branches


**⚠️⚠️⚠️ needs a backport to all `mw-` branches**
