### PR TITLE
fix: change upgrade test 1.39 base version to latest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -160,7 +160,7 @@ jobs:
           # Latest 1.38
           'wmde.12',
           # Latest 1.39
-          'wmde.11',
+          'wmde.13',
         ]
     needs:
       - build
@@ -209,7 +209,7 @@ jobs:
           # Latest 1.38
           'wmde.12-bundle',
           # Latest 1.39
-          'wmde.11-bundle',
+          'wmde.13-bundle',
         ]
 
     env:

--- a/test/suites/upgrade/old-versions/wmde.13-bundle.env
+++ b/test/suites/upgrade/old-versions/wmde.13-bundle.env
@@ -1,0 +1,1 @@
+WIKIBASE_SOURCE_IMAGE_NAME=wikibase/wikibase-bundle:1.39.5-wmde.13

--- a/test/suites/upgrade/old-versions/wmde.13.env
+++ b/test/suites/upgrade/old-versions/wmde.13.env
@@ -1,0 +1,1 @@
+WIKIBASE_SOURCE_IMAGE_NAME=wikibase/wikibase:1.39.5-wmde.13


### PR DESCRIPTION
Now, as wmde.13 is released, we should test updates on main from there.