### PR TITLE
fix: gh built artifact names

### DIFF
--- a/Docker/publish/upload_tar/publish.sh
+++ b/Docker/publish/upload_tar/publish.sh
@@ -11,7 +11,7 @@ if [ -z "$RELEASE_HOST" ] || \
     exit 1;
 fi
 
-ARTIFACT_PATH=/extractedArtifacts/BuildArtifacts
+ARTIFACT_PATH=/extractedArtifacts/TarBalls
 RELEASE_FULL_PATH=$RELEASE_DIR/$RELEASE_MAJOR_VERSION
 
 # Setup ssh-keys

--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -83,7 +83,7 @@ Remove locally created artifacts and use the downloaded ones
 
 ```
 $ make clean
-$ cp artifacts/WORKFLOW_RUN_NUMBER/BuildArtifacts/* artifacts/
+$ cp artifacts/WORKFLOW_RUN_NUMBER/DockerImages/* artifacts/
 $ make test SUITE=<suite-name>
 ```
 

--- a/docs/topics/test-system.md
+++ b/docs/topics/test-system.md
@@ -130,16 +130,16 @@ sudo docker compose -f docker-compose.yml -f docker-compose.extra.yml start wdqs
 
 The service should now be up and running!
 
-## Using images from BuildArtifacts
+## Using images from built artifacts
 
-You load images from tar files that are part of `BuildArtifacts` for any Github run.
+You load images from tar files that are in `DockerImages` for any Github run.
 
 Firstly, find the run summary that you want to load, such as https://github.com/wmde/wikibase-release-pipeline/actions/runs/3446873839.
 
-When authenticated using the `gh` CLI tool, you can download `BuildArtifacts` of any run using the run ID.
+When authenticated using the `gh` CLI tool, you can download `DockerImages` of any run using the run ID.
 
 ```sh
-gh run download 3446873839 -n BuildArtifacts -R wmde/wikibase-release-pipeline
+gh run download 3446873839 -n DockerImages -R wmde/wikibase-release-pipeline
 ```
 
 Once downloaded you can load the compressed images and delete the artifacts from disk in a quick loop.

--- a/publish/docker-compose.yml
+++ b/publish/docker-compose.yml
@@ -16,13 +16,13 @@ services:
       dockerfile: Dockerfile
     privileged: true
     environment:
-      - ELASTICSEARCH_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/elasticsearch.docker.tar.gz
-      - WIKIBASE_BUNDLE_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/wikibase-bundle.docker.tar.gz
-      - WIKIBASE_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/wikibase.docker.tar.gz
-      - WDQS_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/wdqs.docker.tar.gz
-      - WDQS_FRONTEND_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/wdqs-frontend.docker.tar.gz
-      - QUICKSTATEMENTS_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/quickstatements.docker.tar.gz
-      - WDQS_PROXY_DOCKER_PATH=/extractedArtifacts/BuildArtifacts/wdqs-proxy.docker.tar.gz
+      - ELASTICSEARCH_DOCKER_PATH=/extractedArtifacts/DockerImages/elasticsearch.docker.tar.gz
+      - WIKIBASE_BUNDLE_DOCKER_PATH=/extractedArtifacts/DockerImages/wikibase-bundle.docker.tar.gz
+      - WIKIBASE_DOCKER_PATH=/extractedArtifacts/DockerImages/wikibase.docker.tar.gz
+      - WDQS_DOCKER_PATH=/extractedArtifacts/DockerImages/wdqs.docker.tar.gz
+      - WDQS_FRONTEND_DOCKER_PATH=/extractedArtifacts/DockerImages/wdqs-frontend.docker.tar.gz
+      - QUICKSTATEMENTS_DOCKER_PATH=/extractedArtifacts/DockerImages/quickstatements.docker.tar.gz
+      - WDQS_PROXY_DOCKER_PATH=/extractedArtifacts/DockerImages/wdqs-proxy.docker.tar.gz
 
       - WDQS_IMAGE_NAME
       - WDQS_FRONTEND_IMAGE_NAME

--- a/publish/tar-nodocker.sh
+++ b/publish/tar-nodocker.sh
@@ -9,7 +9,7 @@ if [ -z "$RELEASE_HOST" ] || \
     exit 1;
 fi
 
-ARTIFACT_PATH=./artifacts/$WORKFLOW_RUN_NUMBER/BuildArtifacts
+ARTIFACT_PATH=./artifacts/$WORKFLOW_RUN_NUMBER/TarBalls
 RELEASE_FULL_PATH=$RELEASE_DIR/$RELEASE_MAJOR_VERSION
 
 echo "Will upload tarballs from $ARTIFACT_PATH to $RELEASE_HOST at $RELEASE_FULL_PATH"


### PR DESCRIPTION
With the merge of https://github.com/wmde/wikibase-release-pipeline/commit/7686b1a33dc0ca6eed02d813dc098fa7f6c68d51 built artifact names changed. This PR fixes some docs and scripts that still used to old names.

❗ **should probably be backported to `mw-1.39` and `mw-1.40`**