### PR TITLE
chore: bump version for next release

### DIFF
--- a/variables.env
+++ b/variables.env
@@ -1,5 +1,5 @@
 # shellcheck disable=2034 # unused variable
-WMDE_RELEASE_VERSION=wmde.14
+WMDE_RELEASE_VERSION=wmde.15-prerelease
 
 WIKIBASE_BRANCH_NAME=REL1_40
 MEDIAWIKI_BRANCH_NAME=REL1_40


### PR DESCRIPTION
As `wmde.14` branched of, we should change the version in main. Actually, I think we should have done this right after branching off `wmde.14`.