### PR TITLE
T353520: Make Property spec less flakey applying WDIO Intercept

### DIFF
--- a/test/helpers/default-functions.ts
+++ b/test/helpers/default-functions.ts
@@ -315,6 +315,17 @@ export function defaultFunctions(): void {
 			);
 		}
 	);
+
+	browser.addCommand(
+		'waitForPendingRequests',
+		async (): Promise<boolean> => {
+			return browser.waitUntil(
+				async () => {
+					return !!browser.hasPendingRequests();
+				}
+			);
+		}
+	);
 }
 
 export async function skipIfExtensionNotPresent(

--- a/test/helpers/pages/entity/property.page.ts
+++ b/test/helpers/pages/entity/property.page.ts
@@ -2,7 +2,7 @@ import Page from '../page.js';
 
 class Property extends Page {
 	public get save(): ChainablePromiseElement {
-		return $( '=save' );
+		return $( '.wikibase-toolbar-button-save[aria-disabled="false"]' ).$( '=save' );
 	}
 	public get addStatement(): ChainablePromiseElement {
 		return $( '=add statement' );

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -29,6 +29,7 @@
 				"stylelint-config-wikimedia": "0.16.1",
 				"ts-node": "^10.9.1",
 				"typescript": "^5.2.2",
+				"wdio-intercept-service": "^4.4.0",
 				"wdio-mediawiki": "2.4.0",
 				"wdio-wikibase": "^6.0.1"
 			},
@@ -11809,6 +11810,12 @@
 			"dependencies": {
 				"defaults": "^1.0.3"
 			}
+		},
+		"node_modules/wdio-intercept-service": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/wdio-intercept-service/-/wdio-intercept-service-4.4.0.tgz",
+			"integrity": "sha512-9ao5WVTWmr/NEOTwqHNvYPso7Ygzx+PvITaZvYvC5RPXlGv1LPdDdP+WCGzwDlvqdOaty7Nko5BfJDyuBscH7A==",
+			"dev": true
 		},
 		"node_modules/wdio-mediawiki": {
 			"version": "2.4.0",

--- a/test/package.json
+++ b/test/package.json
@@ -25,6 +25,7 @@
 		"stylelint-config-wikimedia": "0.16.1",
 		"ts-node": "^10.9.1",
 		"typescript": "^5.2.2",
+		"wdio-intercept-service": "^4.4.0",
 		"wdio-mediawiki": "2.4.0",
 		"wdio-wikibase": "^6.0.1"
 	},

--- a/test/specs/repo/property.ts
+++ b/test/specs/repo/property.ts
@@ -25,30 +25,30 @@ describe( 'Property', () => {
 				stringPropertyId = await WikibaseApi.createProperty(
 					wikibasePropertyString.urlName
 				);
+				await browser.waitForJobs();
 			} );
 
 			beforeEach( async () => {
 				await Property.open( propertyId );
+				await browser.setupInterceptor();
+			} );
+
+			afterEach( async () => {
+				await browser.waitForPendingRequests();
+				await browser.waitForJobs();
 			} );
 
 			it( 'Should be able to add statement to property', async () => {
 				await Property.addStatement.click();
-
 				// fill out property id for statement
 				await browser.keys( stringPropertyId.split( '' ) );
 				await $( propertyIdSelector( stringPropertyId ) ).click();
 				await browser.keys( 'STATEMENT'.split( '' ) );
-
-				// wait for save button to re-enable
-				await browser.waitForJobs();
 				await Property.save.click();
-
-				await browser.waitForJobs();
 			} );
 
 			it( 'Should be able to see added statement', async () => {
 				await $( '=STATEMENT' );
-
 				const resultStatement = await $(
 					`aria/Property:${stringPropertyId}`
 				).getText();
@@ -57,18 +57,12 @@ describe( 'Property', () => {
 
 			it( 'Should be able to add reference to property', async () => {
 				await Property.addReference.click();
-
-				// fill out property id for reference
 				await $( '.ui-entityselector-input' ).isFocused();
+				// fill out property id for reference
 				await browser.keys( stringPropertyId.split( '' ) );
 				await $( propertyIdSelector( stringPropertyId ) ).click();
 				await browser.keys( 'REFERENCE'.split( '' ) );
-
-				// eslint-disable-next-line wdio/no-pause
-				await browser.pause( 1000 * 1 );
 				await Property.save.click();
-
-				await browser.waitForJobs();
 			} );
 
 			it( 'Should be able to see added reference', async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,12 @@
 		"esModuleInterop": true,
 		"module": "Node16",
 		"target": "es2019",
-		"types": [ "node", "@wdio/globals/types", "@wdio/mocha-framework" ]
+		"types": [
+			"node",
+			"@wdio/globals/types",
+			"@wdio/mocha-framework",
+			"wdio-intercept-service"
+		]
 	},
 	"ts-node": {
 		"files": true

--- a/test/types/wdio.d.ts
+++ b/test/types/wdio.d.ts
@@ -81,6 +81,8 @@ declare namespace WebdriverIO {
 			timeout?: number,
 			timeoutMsg?: string,
 		) => Promise<boolean>;
+
+		waitForPendingRequests: () => Promise<boolean>;
 	}
 
 	interface Element {

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -76,6 +76,10 @@ export const config: WebdriverIO.Config = {
 		]
 	],
 
+	services: [
+		'intercept'
+	],
+
 	// See also: http://mochajs.org
 	mochaOpts: {
 		ui: 'bdd',


### PR DESCRIPTION
https://phabricator.wikimedia.org/T353520

Unfortunately using the WDIO Intercept service doesn't on its own yet make the Property spec entirely not flakey. There are a several things going on here: 

1) Not checking if the "save" button is enabled before clicking, which is remedied here by a better selector in `Property.page.ts`
2) Pending jobs from the API calls in the initial test, remedied by a `waitForJobs` call at the end of that test.
3) AJAX requests being issued once a Statement or Reference is added which don't complete before the page is reloaded, which theoretically should be remedied by the WDIO Intercept service waiting for all AJAX to complete before loading the page. 
4) Possible caching--though I think I have mostly eliminated this as a root cause.

Waiting for AJAX calls to complete does seem to make things mostly reliable (and adds 30 seconds to the test run time). Unfortunately though I have seen at least once the added Reference still not appear on the page after reload with Intercept added. 

In the end I think the best scenario here may be to not use the intercept and simply employ a 2 second browser pause in the `afterTest`. This I suspect will be the most reliable and not add the 30 second overhead for waiting out AJAX calls. However, despite that it's not solving all our problems here, I think the WDIO Intercept service is worth being aware of maybe still including in our test setup.