### PR TITLE
T353625 fix: wdqs out of memory / out of fds

### DIFF
--- a/example/docker-compose.extra.yml
+++ b/example/docker-compose.extra.yml
@@ -50,6 +50,13 @@ services:
     image: "${WDQS_IMAGE_NAME}"
     restart: unless-stopped
     command: /runBlazegraph.sh
+    # Set number of files ulimit high enough, otherwise blazegraph will abort with:
+    # library initialization failed - unable to allocate file descriptor table - out of memory
+    # Appeared on Docker 24.0.5, containerd 1.7.9, Linux 6.6.6, NixOS 23.11
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
     volumes:
       - query-service-data:/wdqs/data
     networks:
@@ -79,6 +86,13 @@ services:
     image: "${WDQS_IMAGE_NAME}"
     restart: unless-stopped
     command: /runUpdate.sh
+    # Set number of files ulimit high enough, otherwise blazegraph will abort with:
+    # library initialization failed - unable to allocate file descriptor table - out of memory
+    # Appeared on Docker 24.0.5, containerd 1.7.9, Linux 6.6.6, NixOS 23.11
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
     depends_on:
     - wdqs
     - wikibase

--- a/test/suites/docker-compose.yml
+++ b/test/suites/docker-compose.yml
@@ -91,6 +91,13 @@ services:
     image: "${WIKIBASE_SUITE_WDQS_IMAGE_URL}"
     restart: always
     command: /runBlazegraph.sh
+    # Set number of files ulimit high enough, otherwise blazegraph will abort with:
+    # library initialization failed - unable to allocate file descriptor table - out of memory
+    # Appeared on Docker 24.0.5, containerd 1.7.9, Linux 6.6.6, NixOS 23.11
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
     networks:
       default:
         aliases:
@@ -120,6 +127,13 @@ services:
     image: "${WIKIBASE_SUITE_WDQS_IMAGE_URL}"
     restart: unless-stopped
     command: /runUpdate.sh
+    # Set number of files ulimit high enough, otherwise blazegraph will abort with:
+    # library initialization failed - unable to allocate file descriptor table - out of memory
+    # Appeared on Docker 24.0.5, containerd 1.7.9, Linux 6.6.6, NixOS 23.11
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
     depends_on:
     - wdqs
     - wikibase


### PR DESCRIPTION
After an update to NixOS 23.11 which ships Docker 24.0.5 at the moment, running WDQS in the test setup broke. This PR fixes it by setting the `ulimit` for file descriptors explicitly.