### PR TITLE
T353528 fix: ghcr docker image upload (#534) backport to mw-1.40

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -292,13 +292,13 @@ jobs:
       matrix:
         docker_image:
           [
-            "wikibase",
-            "wikibase-bundle",
-            "elasticsearch",
-            "wdqs",
-            "wdqs-frontend",
-            "wdqs-proxy",
-            "quickstatements",
+            "wikibase/wikibase",
+            "wikibase/wikibase-bundle",
+            "wikibase/elasticsearch",
+            "wikibase/wdqs",
+            "wikibase/wdqs-frontend",
+            "wikibase/wdqs-proxy",
+            "wikibase/quickstatements",
           ]
 
     steps:


### PR DESCRIPTION
see #534 

depends on #546 