### PR TITLE
T353520: Property and Special:Property no longer flakey

### DIFF
--- a/build/WDQS/README.md
+++ b/build/WDQS/README.md
@@ -6,7 +6,7 @@ Wikibase specific Blazegraph image.
 
 [WDQS](https://gerrit.wikimedia.org/r/admin/repos/wikidata/query/rdf) exposes by default some endpoints and methods that reveal internal details or functionality that might allow for abuse of the system. With the example docker configuration we are using the [WDQS-proxy](../WDQS-proxy/README.md) which filters out all long-running or unwanted requests.
 
-When running WDQS in a setup without WDQS-proxy **please consider disabling these endpoints in some other way**. For more information on how this is tested in this pipeline see the test-cases in [queryservice.ts](../../../test/specs/repo/queryservice.ts)
+When running WDQS in a setup without WDQS-proxy **please consider disabling these endpoints in some other way**. For more information on how this is tested in this pipeline see the test-cases in [queryservice.ts](../../test/specs/repo/queryservice.ts)
 
 ### Upgrading
 

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-use-before-define */
 import { Launcher, RunCommandArguments } from '@wdio/cli';
+import logger from '@wdio/logger';
 import lodash from 'lodash';
 import chalk from 'chalk';
 import yargs from 'yargs';
@@ -159,10 +160,16 @@ export async function runWdio(
 	wdioOpts: Partial<RunCommandArguments>
 ): Promise<number> {
 	try {
+		// `logger` is a singleton and without this line the `<suiteName>/results/wdio.log` of the
+		// first suite in a multiple suite test ran (e.g. `./test.sh all`) is appended for all the
+		// suites in the run
+		logger.clearLogger();
+
 		const wdio = new Launcher(
 			configFilePath,
 			wdioOpts
 		);
+
 		return wdio.run();
 	} catch ( e ) {
 		throw new Error( 'Failed to start the test suite: ' + e.stacktrace );

--- a/test/helpers/json-reporter.ts
+++ b/test/helpers/json-reporter.ts
@@ -30,12 +30,12 @@ class JsonReporter extends WDIOReporter {
 		this.skippedTests.push( { fullTitle: test.fullTitle } );
 	}
 
-	public onTestPass( test: TestStats ): void {
-		this.successfulTests.push( { fullTitle: test.fullTitle } );
+	public onTestPass( { fullTitle, retries, error }: TestStats ): void {
+		this.successfulTests.push( { fullTitle, retries, error } );
 	}
 
-	public onTestFail( test: TestStats ): void {
-		this.failedTests.push( { fullTitle: test.fullTitle, error: test.error } );
+	public onTestFail( { fullTitle, retries, error }: TestStats ): void {
+		this.failedTests.push( { fullTitle, retries, error } );
 	}
 
 	public onSuiteEnd( suiteStats: SuiteStats ): void {

--- a/test/helpers/pages/entity/property.page.ts
+++ b/test/helpers/pages/entity/property.page.ts
@@ -1,14 +1,14 @@
 import Page from '../page.js';
 
 class Property extends Page {
-	public get saveStatement(): ChainablePromiseElement {
+	public get saveStatementLink(): ChainablePromiseElement {
 		// Only return save button if enabled
 		return $( '.wikibase-toolbar-button-save[aria-disabled="false"]' ).$( '=save' );
 	}
-	public get addStatement(): ChainablePromiseElement {
+	public get addStatementLink(): ChainablePromiseElement {
 		return $( '=add statement' );
 	}
-	public get addReference(): ChainablePromiseElement {
+	public get addReferenceLink(): ChainablePromiseElement {
 		return $( '=add reference' );
 	}
 

--- a/test/setup/TestEnv.ts
+++ b/test/setup/TestEnv.ts
@@ -55,13 +55,15 @@ export default class TestEnv {
 
 			await this.stopServices();
 			await this.startServices();
-			await this.waitForServices();
 
 			if ( this.settings.runHeaded ) {
 				console.log(
 					'💻 Open http://localhost:7900/?autoconnect=1&resize=scale to observe headed tests.\n'
 				);
 			}
+
+			await this.waitForServices();
+
 		} catch ( e ) {
 			throw new SevereServiceError( e );
 		}

--- a/test/specs/repo/property.ts
+++ b/test/specs/repo/property.ts
@@ -43,6 +43,8 @@ describe( 'Property', function () {
 			} );
 
 			it( 'Should be able to see added statement', async () => {
+				this.retries( 4 );
+
 				await $( '=STATEMENT' );
 				const resultStatement = await $(
 					`aria/Property:${stringPropertyId}`

--- a/test/specs/repo/property.ts
+++ b/test/specs/repo/property.ts
@@ -12,7 +12,7 @@ const dataTypes = [ wikibasePropertyItem, wikibasePropertyString ];
 
 const propertyIdSelector = ( id: string ): string => `=${id} (${id})`; // =P1 (P1)
 
-describe( 'Property', () => {
+describe( 'Property', function () {
 	// eslint-disable-next-line mocha/no-setup-in-describe
 	dataTypes.forEach( ( dataType: WikibasePropertyType ) => {
 		// eslint-disable-next-line mocha/no-setup-in-describe
@@ -32,21 +32,14 @@ describe( 'Property', () => {
 				await Property.open( propertyId );
 			} );
 
-			afterEach( async () => {
-				// Extra pause to make sure AJAX requests complete before navigating away,
-				// see: https://phabricator.wikimedia.org/T353520
-				// eslint-disable-next-line wdio/no-pause
-				await browser.pause( 2000 * 1 );
-			} );
-
 			it( 'Should be able to add statement to property', async () => {
-				await Property.addStatement.click();
+				await Property.addStatementLink.click();
 				// fill out property id for statement
 				await browser.keys( stringPropertyId.split( '' ) );
 				await $( propertyIdSelector( stringPropertyId ) ).click();
 				await browser.keys( 'STATEMENT'.split( '' ) );
 				// wait for save button to re-enable
-				await Property.saveStatement.click();
+				await Property.saveStatementLink.click();
 			} );
 
 			it( 'Should be able to see added statement', async () => {
@@ -58,21 +51,25 @@ describe( 'Property', () => {
 			} );
 
 			it( 'Should be able to add reference to property', async () => {
-				await Property.addReference.click();
+				await Property.addReferenceLink.click();
 				// fill out property id for reference
 				await $( '.ui-entityselector-input' ).isFocused();
 				await browser.keys( stringPropertyId.split( '' ) );
 				await $( propertyIdSelector( stringPropertyId ) ).click();
 				await browser.keys( 'REFERENCE'.split( '' ) );
-				await Property.saveStatement.click();
+				await Property.saveStatementLink.click();
 			} );
 
-			it( 'Should be able to see added reference', async () => {
+			it( 'Should be able to see added reference', async function () {
+				this.retries( 4 );
+
 				await $( '=1 reference' ).click();
 				await $( '=REFERENCE' );
 			} );
 
-			it( 'Should contain statement and reference in EntityData', async () => {
+			it( 'Should contain statement and reference in EntityData', async function () {
+				this.retries( 4 );
+
 				const response = await browser.makeRequest(
 					`${testEnv.vars.WIKIBASE_URL}/wiki/Special:EntityData/${propertyId}.json`
 				);

--- a/test/specs/repo/special-property.ts
+++ b/test/specs/repo/special-property.ts
@@ -38,9 +38,7 @@ describe( 'Special:NewProperty', function () {
 		} );
 	} );
 
-	it( 'Should be able to see newly created properties in list of properties special page', async function () {
-		this.retries( 4 )
-
+	it( 'Should be able to see newly created properties in list of properties special page', async () => {
 		await SpecialListProperties.openParams( {
 			dataType: wikibasePropertyString.urlName,
 			limit: 1000
@@ -57,18 +55,20 @@ describe( 'Special:NewProperty', function () {
 		);
 		await SpecialNewProperty.submit();
 
-		// wait for the $wgWBRepoSettings['sharedCacheDuration'] cache to
-		// timeout, so the list of properties reflects the change
-		// eslint-disable-next-line wdio/no-pause
-		// await browser.pause( 2000 );
-
-		await SpecialListProperties.openParams( {
-			dataType: wikibasePropertyString.urlName,
-			limit: 1000
+		let numberOfPropertiesAfter;
+		await browser.waitUntil( async () => {
+			await SpecialListProperties.openParams( {
+				dataType: wikibasePropertyString.urlName,
+				limit: 1000
+			} );
+			numberOfPropertiesAfter = await SpecialListProperties.properties.length;
+			return numberOfPropertiesAfter === numberOfPropertiesBefore + 1;
+		}, {
+			// wait for the $wgWBRepoSettings['sharedCacheDuration'] cache to
+			// timeout, so the list of properties reflects the change
+			interval: 1000,
+			timeout: 10000,
+			timeoutMsg: 'expected total number of reflect new property in list within 10 seconds'
 		} );
-		const numberOfPropertiesAfter =
-			await SpecialListProperties.properties.length;
-
-		assert.strictEqual( numberOfPropertiesAfter, numberOfPropertiesBefore + 1 );
 	} );
 } );

--- a/test/specs/repo/special-property.ts
+++ b/test/specs/repo/special-property.ts
@@ -38,7 +38,9 @@ describe( 'Special:NewProperty', function () {
 		} );
 	} );
 
-	it( 'Should be able to see newly created properties in list of properties special page', async () => {
+	it( 'Should be able to see newly created properties in list of properties special page', async function () {
+		this.retries( 4 )
+
 		await SpecialListProperties.openParams( {
 			dataType: wikibasePropertyString.urlName,
 			limit: 1000
@@ -58,7 +60,7 @@ describe( 'Special:NewProperty', function () {
 		// wait for the $wgWBRepoSettings['sharedCacheDuration'] cache to
 		// timeout, so the list of properties reflects the change
 		// eslint-disable-next-line wdio/no-pause
-		await browser.pause( 2000 );
+		// await browser.pause( 2000 );
 
 		await SpecialListProperties.openParams( {
 			dataType: wikibasePropertyString.urlName,

--- a/test/types/test-results.ts
+++ b/test/types/test-results.ts
@@ -1,5 +1,6 @@
 export type TestResult = {
 	fullTitle: string;
+	retries?: number;
 	error?: Error;
 };
 


### PR DESCRIPTION
Uses Mocha "retries" for Property test, and WDIO `browser.waitUntil()` for Special:Property. 

This fixes flakiness by expecting things to be a little latent and continuing to try until expected results appear. I think this the simplest and most clear solution of the options evaluated, as well as has proved to be the most reliable in my testing.  I don't think we'll continue to see failures in this setup. Slightly better than a long `browser.pause()`, which could achieve the same thing for Special:Property, but this way is more descriptive and doesn't always add the full base "pause" time to the tests. In the case of Property we need to make sure the page gets reload to check for the values each time, so `this.retries( 4 )` on the related tests also will reload the page up to 4 times looking for the new value.