### PR TITLE
Property Test Retry Fix

### DIFF
--- a/test/specs/repo/property.ts
+++ b/test/specs/repo/property.ts
@@ -44,7 +44,7 @@ describe( 'Property', function () {
 				await PropertyPage.saveStatementLink.click();
 			} );
 
-			it( 'Should be able to see added statement', async () => {
+			it( 'Should be able to see added statement', async function () {
 				this.retries( 4 );
 				await expect( $( `div=${statementText}` ) ).toExist();
 				await expect( $( `aria/Property:${stringPropertyId}` ) ).toHaveText(


### PR DESCRIPTION
Using an arrow function makes `this.retries` non-functional; this just corrects that error.