### PR TITLE
T351720 tag GHCR containers with version too

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -180,8 +180,7 @@ jobs:
     # - from main branch builds
     # - from release branch builds and 
     # - builds from PRs going to a release branch
-    # TODO: reenable the line below when debugging is done
-    # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/mw-') || startsWith(github.base_ref, 'mw-')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/mw-') || startsWith(github.base_ref, 'mw-')
 
     needs:
       - test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: 🏗️🧪 Build and Test
 
 on:
   push:
@@ -44,8 +44,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build
-        run: ./build.sh --save-image --extract-tarball ${{ matrix.component }}
         shell: bash
+        run: ./build.sh --save-image --extract-tarball ${{ matrix.component }}
 
       - name: Upload results
         uses: ./.github/actions/upload-results
@@ -180,7 +180,8 @@ jobs:
     # - from main branch builds
     # - from release branch builds and 
     # - builds from PRs going to a release branch
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/mw-') || startsWith(github.base_ref, 'mw-')
+    # TODO: reenable the line below when debugging is done
+    # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/mw-') || startsWith(github.base_ref, 'mw-')
 
     needs:
       - test
@@ -223,8 +224,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Store built docker image on GHCR
-        uses: wmde/tag-push-ghcr-action@v3
-        with:
-          image_name: ${{ matrix.docker_image }}
-          tag: ${{ github.run_id }}
+      - name: Push docker image to GHCR
+        shell: bash
+        run: |
+          set -x
+
+          # Get the docker tag name != latest of the image we are currently looking at. (The version string that is)
+          version_tag=$(docker image ls | grep -e '^${{ matrix.docker_image }} ' | grep -v latest | awk '{print $2}' | head -n 1)
+
+          # We need to retag the container for GHCR because the current tag is targetting docker hub.
+          # We will push two tags to GHCR, a version tag and a tag representing the current CI pipeline run id.
+          # Let's create "from" and "to" container URLs first.
+          from_url=${{ matrix.docker_image }}:"$version_tag"
+          to_url_version=ghcr.io/${{ github.repository_owner }}/${{ matrix.docker_image }}:"$version_tag"
+          to_url_run_id=ghcr.io/${{ github.repository_owner }}/${{ matrix.docker_image }}:${{ github.run_id }}
+
+          # Retag and push
+          docker tag "$from_url" "$to_url_version"
+          docker tag "$from_url" "$to_url_run_id"
+          docker push "$to_url_version"
+          docker push "$to_url_run_id"


### PR DESCRIPTION
This PR is part of https://phabricator.wikimedia.org/T351720

This is just a small step in order to close the ticket.

Currently we only tag our containers on GHCR with CI job run id.
![screenshot-20240214103947](https://github.com/wmde/wikibase-release-pipeline/assets/80712/32941efa-9469-4a21-ae46-6ef54da9c93f)

This run number is not intuitive, a version string should be easier to handle, especially during testing of prerelease builds (the main role of GHCR for us at the moment).

With this PR, container tags on GHCR will look like this:
![screenshot-20240214104200](https://github.com/wmde/wikibase-release-pipeline/assets/80712/15e3cb3e-e5f9-4da3-b7d6-fbe8d2b86e21)
