### PR TITLE
Release WMDE.17 Example Update

### DIFF
--- a/example/template.env
+++ b/example/template.env
@@ -2,13 +2,13 @@
 # WARNING: Do not add comments on the same line as env vars, as in some environments they will be included in the var!
 
 ## Image Configuration
-WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.40.1-wmde.14
-WDQS_IMAGE_NAME=wikibase/wdqs:0.3.135-wmde.14
-WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.14
-ELASTICSEARCH_IMAGE_NAME=wikibase/elasticsearch:7.10.2-wmde.14
-WIKIBASE_BUNDLE_IMAGE_NAME=wikibase/wikibase-bundle:1.40.1-wmde.14
-QUICKSTATEMENTS_IMAGE_NAME=wikibase/quickstatements:wmde.14
-WDQS_PROXY_IMAGE_NAME=wikibase/wdqs-proxy:wmde.14
+WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.40.1-wmde.17
+WDQS_IMAGE_NAME=wikibase/wdqs:0.3.135-wmde.17
+WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.17
+ELASTICSEARCH_IMAGE_NAME=wikibase/elasticsearch:7.10.2-wmde.17
+WIKIBASE_BUNDLE_IMAGE_NAME=wikibase/wikibase-bundle:1.40.1-wmde.17
+QUICKSTATEMENTS_IMAGE_NAME=wikibase/quickstatements:wmde.17
+WDQS_PROXY_IMAGE_NAME=wikibase/wdqs-proxy:wmde.17
 MYSQL_IMAGE_NAME=mariadb:10.11
 
 ## Mediawiki Configuration

--- a/example/template.env
+++ b/example/template.env
@@ -2,11 +2,11 @@
 # WARNING: Do not add comments on the same line as env vars, as in some environments they will be included in the var!
 
 ## Image Configuration
-WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.40.1-wmde.17
+WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.41.0-wmde.17
 WDQS_IMAGE_NAME=wikibase/wdqs:0.3.135-wmde.17
 WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.17
 ELASTICSEARCH_IMAGE_NAME=wikibase/elasticsearch:7.10.2-wmde.17
-WIKIBASE_BUNDLE_IMAGE_NAME=wikibase/wikibase-bundle:1.40.1-wmde.17
+WIKIBASE_BUNDLE_IMAGE_NAME=wikibase/wikibase-bundle:1.41.0-wmde.17
 QUICKSTATEMENTS_IMAGE_NAME=wikibase/quickstatements:wmde.17
 WDQS_PROXY_IMAGE_NAME=wikibase/wdqs-proxy:wmde.17
 MYSQL_IMAGE_NAME=mariadb:10.11

--- a/example/template.env
+++ b/example/template.env
@@ -3,7 +3,7 @@
 
 ## Image Configuration
 WIKIBASE_IMAGE_NAME=wikibase/wikibase:1.41.0-wmde.17
-WDQS_IMAGE_NAME=wikibase/wdqs:0.3.135-wmde.17
+WDQS_IMAGE_NAME=wikibase/wdqs:0.3.137-wmde.17
 WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.17
 ELASTICSEARCH_IMAGE_NAME=wikibase/elasticsearch:7.10.2-wmde.17
 WIKIBASE_BUNDLE_IMAGE_NAME=wikibase/wikibase-bundle:1.41.0-wmde.17

--- a/variables.env
+++ b/variables.env
@@ -7,7 +7,7 @@
 # Append -prerelease while working on releases.
 # Remove -prerelease when ready to merge release to the release branch.
 # Call it main on the main branch.
-WMDE_RELEASE_VERSION=main
+WMDE_RELEASE_VERSION=wmde.17
 
 
 # ##############################################################################


### PR DESCRIPTION
Will fail until #624 is merged and images for WMDE.17 are released on dockerhub. Merge after that.

#### Hacky workaround
Delete the wmde.17 tag before merging this, this will be a re-release. Fix for that pending.