### PR TITLE
Pull Current Release Tooling into MW-1.40 Prep

### DIFF
--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -14,12 +14,12 @@ permissions:
 
 jobs:
   _:
-    if: github.event.pull_request.merged == 'true'
+    if: github.event.pull_request.merged == true
 
     uses: ./.github/workflows/_build_test.yml
 
   tag-release:
-    if: github.event.pull_request.merged == 'true'
+    if: github.event.pull_request.merged == true
 
     needs: _
 
@@ -49,7 +49,7 @@ jobs:
           fi
 
   publish-dockerhub:
-    if: github.event.pull_request.merged == 'true'
+    if: github.event.pull_request.merged == true
 
     needs: tag-release
 

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -1,7 +1,9 @@
 name: 📦 Build Test Tag and Publish Release
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - "mw-*"
 
@@ -12,10 +14,15 @@ permissions:
 
 jobs:
   _:
+    if: github.event.pull_request.merged == 'true'
+
     uses: ./.github/workflows/_build_test.yml
 
   tag-release:
+    if: github.event.pull_request.merged == 'true'
+
     needs: _
+
     runs-on: ubuntu-latest
 
     steps:
@@ -42,9 +49,12 @@ jobs:
           fi
 
   publish-dockerhub:
+    if: github.event.pull_request.merged == 'true'
+
     needs: tag-release
 
     runs-on: ubuntu-latest
+
     timeout-minutes: 30
 
     steps:

--- a/build.sh
+++ b/build.sh
@@ -19,13 +19,10 @@ DOCKER_BUILD_CACHE_OPT=""
 
 # ℹ️ Update Commit Hashes
 function update_commit_hashes {
-    docker compose \
-    --file test/docker-compose.yml \
-    --env-file test/test-runner.env \
-    run --rm --build test-runner -c "
-    cd ..
-    python3 -m pip install requests bs4 lxml
-    python3 update_commits.py
+    docker build ./test -t wikibase-test-runner
+    docker run --rm -v "$(pwd)":/workspace wikibase-test-runner bash -c "
+        cd /workspace
+        python3 update_commits.py
     "
 }
 
@@ -218,6 +215,7 @@ for arg in "$@"; do
             ;;
         update_hashes)
             update_commit_hashes
+            exit 0
             ;;
         -n|--no-cache)
             DOCKER_BUILD_CACHE_OPT="--no-cache"

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,17 @@ source ./versions.inc.sh
 
 DOCKER_BUILD_CACHE_OPT=""
 
+# ℹ️ Update Commit Hashes
+function update_commit_hashes {
+    docker compose \
+    --file test/docker-compose.yml \
+    --env-file test/test-runner.env \
+    run --rm --build test-runner -c "
+    cd ..
+    python3 -m pip install requests bs4 lxml
+    python3 update_commits.py
+    "
+}
 
 # wikibase/wdqs -> wdqs
 function image_url_to_image_name {
@@ -204,6 +215,9 @@ for arg in "$@"; do
         all)
             build_all
             build_target_set=true
+            ;;
+        update_hashes)
+            update_commit_hashes
             ;;
         -n|--no-cache)
             DOCKER_BUILD_CACHE_OPT="--no-cache"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     pip3 install --no-cache-dir --upgrade \
         pip \
-        setuptools
+        setuptools \
+        requests \
+        bs4 \
+        lxml
 
 WORKDIR /usr/src/test/
 

--- a/test/specs/repo/special-property.ts
+++ b/test/specs/repo/special-property.ts
@@ -28,6 +28,8 @@ describe( 'Special:NewProperty', function () {
 			} );
 
 			it( `Should be able to create a new property of datatype ${dataType.name}`, async () => {
+				this.retries( 4 );
+
 				await SpecialNewPropertyPage.open();
 
 				await SpecialNewPropertyPage.labelInput.setValue(

--- a/update_commits.py
+++ b/update_commits.py
@@ -28,7 +28,7 @@ gerrit_pattern = re.compile(
 def parse_gerrit_commit(response: requests.Response) -> str:
     """Parse webpage using BeautifulSoup"""
     soup = BeautifulSoup(response.content, "lxml")
-    return soup.find("th", text="commit").next_sibling.text
+    return soup.find("th", string="commit").next_sibling.text
 
 
 github_pattern = re.compile(

--- a/update_commits.py
+++ b/update_commits.py
@@ -21,7 +21,7 @@ def get_commit(variable: str, url: str, parse_commit: callable, previous_commit:
 
 
 gerrit_pattern = re.compile(
-    r"# (https://gerrit.*)[ \t\r\n]*([A-Z]+_COMMIT)=([0-9a-f]+)"
+    r"# (https://gerrit.*)[ \t\r\n]*([A-Z_]+_COMMIT)=([0-9a-f]+)"
 )
 
 
@@ -32,7 +32,7 @@ def parse_gerrit_commit(response: requests.Response) -> str:
 
 
 github_pattern = re.compile(
-    r"# (https://github\.com/(.*/commits.*))[ \t\r\n]*([A-Z]+_COMMIT)=([0-9a-f]+)"
+    r"# (https://github\.com/(.*/commits.*))[ \t\r\n]*([A-Z_]+_COMMIT)=([0-9a-f]+)"
 )
 
 
@@ -43,7 +43,7 @@ def parse_github_commit(response: requests.Response) -> str:
 
 
 bitbucket_pattern = re.compile(
-    r"# (https://bitbucket\.org/(.*/commits)/branch/master)[ \t\r\n]*([A-Z]+_COMMIT)=([0-9a-f]+)"
+    r"# (https://bitbucket\.org/(.*/commits)/branch/master)[ \t\r\n]*([A-Z_]+_COMMIT)=([0-9a-f]+)"
 )
 
 

--- a/update_commits.py
+++ b/update_commits.py
@@ -1,0 +1,109 @@
+import re, requests, json
+from bs4 import BeautifulSoup
+
+
+def get_commit(variable: str, url: str, parse_commit: callable, previous_commit: str):
+    print(f"Variable:\t{variable}")
+    print(f"\tURL:\t{url}")
+    try:
+        response = requests.get(url)
+        commit = parse_commit(response)
+        if previous_commit != commit:
+            print(f"\tOld Commit:\t{previous_commit}")
+            print(f"\tNew Commit:\t{commit}")
+            return commit
+        else:
+            print(f"\tCommit:\t{commit}")
+            return False
+    except Exception as exc:
+        print(f"\tError:\t{exc}")
+        return False
+
+
+gerrit_pattern = re.compile(
+    r"# (https://gerrit.*)[ \t\r\n]*([A-Z]+_COMMIT)=([0-9a-f]+)"
+)
+
+
+def parse_gerrit_commit(response: requests.Response) -> str:
+    """Parse webpage using BeautifulSoup"""
+    soup = BeautifulSoup(response.content, "lxml")
+    return soup.find("th", text="commit").next_sibling.text
+
+
+github_pattern = re.compile(
+    r"# (https://github\.com/(.*/commits.*))[ \t\r\n]*([A-Z]+_COMMIT)=([0-9a-f]+)"
+)
+
+
+def parse_github_commit(response: requests.Response) -> str:
+    """Fetch from API"""
+    data = json.loads(response.content)
+    return data["sha"]
+
+
+bitbucket_pattern = re.compile(
+    r"# (https://bitbucket\.org/(.*/commits)/branch/master)[ \t\r\n]*([A-Z]+_COMMIT)=([0-9a-f]+)"
+)
+
+
+def parse_bitbucket_commit(response: requests.Response) -> str:
+    """Fetch from API"""
+    data = json.loads(response.content)
+    return data["values"][0]["hash"]
+
+
+def run():
+    with open("variables.env", "r") as variable_file:
+        variable_contents = variable_file.read()
+
+    mediawiki_match = re.search(r"MEDIAWIKI_VERSION=(\d+)\.(\d+)", variable_contents)
+    rel = f"REL{mediawiki_match.group(1)}_{mediawiki_match.group(2)}"
+    print(f"Mediawiki Version:\t{mediawiki_match.group(1)}.{mediawiki_match.group(2)}")
+    variable_contents = re.sub(r"\bREL\d+_\d+", rel, variable_contents)
+
+    for gerrit_commit in re.findall(gerrit_pattern, variable_contents):
+        if commit := get_commit(
+            gerrit_commit[1],
+            gerrit_commit[0],
+            parse_gerrit_commit,
+            gerrit_commit[2],
+        ):
+            variable_contents = re.sub(
+                f"{gerrit_commit[1]}=[0-9a-f]+",
+                f"{gerrit_commit[1]}={commit}",
+                variable_contents,
+            )
+
+    for github_commit in re.findall(github_pattern, variable_contents):
+        if commit := get_commit(
+            github_commit[2],
+            f"https://api.github.com/repos/{github_commit[1]}",
+            parse_github_commit,
+            github_commit[3],
+        ):
+            variable_contents = re.sub(
+                f"{github_commit[2]}=[0-9a-f]+",
+                f"{github_commit[2]}={commit}",
+                variable_contents,
+            )
+
+    for bitbucket_commit in re.findall(bitbucket_pattern, variable_contents):
+        if commit := get_commit(
+            bitbucket_commit[2],
+            f"https://bitbucket.org/!api/2.0/repositories/{bitbucket_commit[1]}",
+            parse_bitbucket_commit,
+            bitbucket_commit[3],
+        ):
+            variable_contents = re.sub(
+                f"{bitbucket_commit[2]}=[0-9a-f]+",
+                f"{bitbucket_commit[2]}={commit}",
+                variable_contents,
+            )
+
+    with open("variables.env", "w") as variable_file:
+        variable_file.write(variable_contents)
+
+
+if __name__ == "__main__":
+    run()

--- a/variables.env
+++ b/variables.env
@@ -79,17 +79,16 @@ VISUALEDITOR_COMMIT=00b627cb83f95a6dc62c640969429ab99c8cad2e
 WIKIBASECIRRUSSEARCH_COMMIT=c88e34b0b2f6dbeb7f69cacdd40d95e6101f9807
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseManifest/+/refs/heads/REL1_40
 WIKIBASEMANIFEST_COMMIT=10f0ddcb7eac28f56999f983f169cf7b1c6e240a
-# https://github.com/ProfessionalWiki/WikibaseLocalMedia/tree/master
+# https://github.com/ProfessionalWiki/WikibaseLocalMedia/commits/master
 WIKIBASELOCALMEDIA_COMMIT=74c3f70893ffd76feefa9f1e3d77052db20ec3ac
-# https://github.com/ProfessionalWiki/WikibaseEdtf/tree/master
+# https://github.com/ProfessionalWiki/WikibaseEdtf/commits/master
 WIKIBASEEDTF_COMMIT=5596403a27d8e4a5ac044257c49be3e0685318a6
 # https://github.com/magnusmanske/quickstatements/commits/master
 QUICKSTATEMENTS_COMMIT=c4b2c6b086b319aa32dcdd7a323edf188faaa66d
 # https://bitbucket.org/magnusmanske/magnustools/commits/branch/master
 MAGNUSTOOLS_COMMIT=5b8cea412000072a2c8753023c11472a4ac11ef5
-# https://gerrit.wikimedia.org/r/plugins/gitiles/wikidata/query/gui/
-# Included due to localization updates
-WDQSQUERYGUI_COMMIT=4f355e5e1ee4747471b6cedb2fc78fe29f9c8cb7
+# https://gerrit.wikimedia.org/r/plugins/gitiles/wikidata/query/gui/+/refs/heads/master
+WDQSQUERYGUI_COMMIT=eb1825b3431f3adf47cd774bf52344024e2f11e9
 
 # Image URLs for the docker images built by us.
 # "wikibase/" is our prefix at docker hub, our default distribution point.

--- a/variables.env
+++ b/variables.env
@@ -149,7 +149,6 @@ WIKIBASEEDTF_COMMIT=5596403a27d8e4a5ac044257c49be3e0685318a6
 QUICKSTATEMENTS_COMMIT=c4b2c6b086b319aa32dcdd7a323edf188faaa66d
 # https://bitbucket.org/magnusmanske/magnustools/commits/branch/master
 MAGNUSTOOLS_COMMIT=5b8cea412000072a2c8753023c11472a4ac11ef5
-# https://gerrit.wikimedia.org/r/plugins/gitiles/wikidata/query/gui/
 
 
 # ##############################################################################

--- a/variables.env
+++ b/variables.env
@@ -1,31 +1,76 @@
 # shellcheck disable=2034 # unused variable
+
+# ##############################################################################
+# Our version string
+# ##############################################################################
+# Used for docker image tags on GHCR and dockerhub.
+# Append -prerelease while working on releases.
+# Remove -prerelease when ready to merge release to the release branch.
+# Call it main on the main branch.
 WMDE_RELEASE_VERSION=wmde.16
 
+
+# ##############################################################################
+# Mediawiki version
+# ##############################################################################
+# Update only patch versions for security releases.
+# Choose latest version for major releases.
 # https://hub.docker.com/_/mediawiki
 MEDIAWIKI_VERSION=1.40.2
 MEDIAWIKI_IMAGE_URL=mediawiki:1.40.2
 
-# WDQS_VERSION 0.3.137 is latest release on 2024-02-02
+
+# ##############################################################################
+# Wikidata Query Service Version
+# ##############################################################################
+# Does not follow laws of god or men.
+# Update to the latest version for major releases.
+# Reason about changes for patch versions.
 # as per https://github.com/wikimedia/wikidata-query-rdf/tags
 # and https://archiva.wikimedia.org/repository/releases/org/wikidata/query/rdf/service/
 # Compare to previous version: https://github.com/wikimedia/wikidata-query-rdf/compare/query-service-parent-0.3.135...query-service-parent-0.3.137
 WDQS_VERSION=0.3.137
 
-# NOTE ELASTICSEARCH_VERSION 7.10.3+ is release under a non-osi approved license
+
+# ##############################################################################
+# Elasticsearch
+# ##############################################################################
+# ELASTICSEARCH_VERSION 7.10.3+ is release under a non-osi approved license
 # 7.10.2 is currently being used by the WMF 20230223
+# We cannot change this at the moment
 ELASTICSEARCH_VERSION=7.10.2
 ELASTICSEARCH_IMAGE_URL=docker.elastic.co/elasticsearch/elasticsearch:7.10.2
 
+
+# ##############################################################################
+# Elasticsearch Plugins
+# ##############################################################################
+# Do not update for patch version unless there is a critical fix.
+# Update to latest for major releases.
+#
 # https://central.sonatype.com/artifact/org.wikimedia.search/extra
+# https://github.com/wikimedia/search-extra/compare/extra-parent-7.10.2-wmf4...extra-parent-7.10.2-wmf10
 ELASTICSEARCH_PLUGIN_WIKIMEDIA_EXTRA=7.10.2-wmf4
 
 # https://central.sonatype.com/artifact/org.wikimedia.search.highlighter/experimental-highlighter-elasticsearch-plugin
 ELASTICSEARCH_PLUGIN_WIKIMEDIA_HIGHLIGHTER=7.10.2
 
-# https://docker-registry.wikimedia.org/releng/composer-php82/tags/
+
+# ##############################################################################
+# PHP Composer
+# ##############################################################################
 # Just used for building - PHP's NPM
+# Typically, no need to update.
+# https://docker-registry.wikimedia.org/releng/composer-php82/tags/
 COMPOSER_IMAGE_URL=docker-registry.wikimedia.org/releng/composer-php82:0.1.0-s3
 
+
+# ##############################################################################
+# Third party base images
+# ##############################################################################
+# Update only patch versions for security releases.
+# Choose latest LTS version for major releases.
+#
 # https://hub.docker.com/_/mariadb
 # https://mariadb.org/mariadb/all-releases/
 MARIADB_IMAGE_URL=mariadb:10.9
@@ -49,6 +94,14 @@ JDK_IMAGE_URL=openjdk:8-jdk-alpine
 # https://hub.docker.com/_/debian
 DEBIAN_IMAGE_URL=debian:bookworm-slim
 
+
+# ##############################################################################
+# WMF maintained extensions
+# ##############################################################################
+# Updated automatically by ./build.sh update_hashes
+# Versions in REL_ branches ensure compatibility with respective mediawiki versions.
+# Shouldn't require much of a review.
+#
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Wikibase/+/refs/heads/REL1_40
 WIKIBASE_COMMIT=903c3f9d0513d4e847727d73b0ab5c742c2d2f09
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Babel/+/refs/heads/REL1_40
@@ -79,6 +132,15 @@ VISUALEDITOR_COMMIT=00b627cb83f95a6dc62c640969429ab99c8cad2e
 WIKIBASECIRRUSSEARCH_COMMIT=c88e34b0b2f6dbeb7f69cacdd40d95e6101f9807
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseManifest/+/refs/heads/REL1_40
 WIKIBASEMANIFEST_COMMIT=10f0ddcb7eac28f56999f983f169cf7b1c6e240a
+
+
+# ##############################################################################
+# Community maintained extensions
+# ##############################################################################
+# Updated automatically by ./build.sh update_hashes
+# Those extensions follow arbitrary versioning strategies. Their compatibility
+# with mediawiki versions has to be checked explicitly. Review carefully.
+#
 # https://github.com/ProfessionalWiki/WikibaseLocalMedia/commits/master
 WIKIBASELOCALMEDIA_COMMIT=74c3f70893ffd76feefa9f1e3d77052db20ec3ac
 # https://github.com/ProfessionalWiki/WikibaseEdtf/commits/master
@@ -87,8 +149,22 @@ WIKIBASEEDTF_COMMIT=5596403a27d8e4a5ac044257c49be3e0685318a6
 QUICKSTATEMENTS_COMMIT=c4b2c6b086b319aa32dcdd7a323edf188faaa66d
 # https://bitbucket.org/magnusmanske/magnustools/commits/branch/master
 MAGNUSTOOLS_COMMIT=5b8cea412000072a2c8753023c11472a4ac11ef5
+# https://gerrit.wikimedia.org/r/plugins/gitiles/wikidata/query/gui/
+
+
+# ##############################################################################
+# Wikidata Query Gui AKA WDQS Frontend
+# ##############################################################################
+# Updated automatically by ./build.sh update_hashes
+# No versioning scheme. Review changes carefully.
+#
 # https://gerrit.wikimedia.org/r/plugins/gitiles/wikidata/query/gui/+/refs/heads/master
 WDQSQUERYGUI_COMMIT=eb1825b3431f3adf47cd774bf52344024e2f11e9
+
+
+# ##############################################################################
+# Further settings
+# ##############################################################################
 
 # Image URLs for the docker images built by us.
 # "wikibase/" is our prefix at docker hub, our default distribution point.

--- a/variables.env
+++ b/variables.env
@@ -158,7 +158,7 @@ MAGNUSTOOLS_COMMIT=5b8cea412000072a2c8753023c11472a4ac11ef5
 # No versioning scheme. Review changes carefully.
 #
 # https://gerrit.wikimedia.org/r/plugins/gitiles/wikidata/query/gui/+/refs/heads/master
-WDQSQUERYGUI_COMMIT=eb1825b3431f3adf47cd774bf52344024e2f11e9
+WDQSQUERYGUI_COMMIT=4f355e5e1ee4747471b6cedb2fc78fe29f9c8cb7
 
 
 # ##############################################################################


### PR DESCRIPTION
Commits from main include:

- Minor updates to `build_test_publish_release.yml`
- Organization and commenting of `variables.env`
- The `update_commits.py` script, and the updates to `build.sh` to use it, to make updating `variables.env` easier

Omitted:

- Linting and formatting changes
- Removal of docs/diagrams
- Updates to build Dockerfiles
- Updates to tests:
  - Moving from `assert` to `expect`
  - Universal kebab-case
  - Return types
  - `function () {}` notation instead of `() => {}`
  - npm package updates
  - use of `page.open()`
  - 