### PR TITLE
T358475 replace personal dockerhub account with generic one

### DIFF
--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -88,6 +88,8 @@ jobs:
             "quickstatements"
           )
 
+          echo "::debug::start listing images:"
           for image in "${images[@]}"; do
-            echo "wikibase/${image}"
+            echo "::debug::wikibase/${image}"
           done
+          echo "::debug::end images list"

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -2,10 +2,8 @@ name: 📦 Build Test Tag and Publish Release
 
 on:
   pull_request:
-    types:
-      - closed
     branches:
-      - "mw-*"
+      - "T358475-*"
 
 permissions:
   contents: write
@@ -48,9 +46,6 @@ jobs:
           fi
 
   publish-dockerhub:
-    if: github.event.pull_request.merged == true
-
-    needs: tag-release
 
     runs-on: ubuntu-latest
 
@@ -73,23 +68,14 @@ jobs:
         run: |
           set -x
 
-          source ./variables.env
-          source ./versions.inc.sh
-
           docker image ls
 
           images=(
-            "wikibase"
-            "wikibase-bundle"
-            "elasticsearch"
-            "wdqs"
-            "wdqs-frontend"
             "wdqs-proxy"
-            "quickstatements"
           )
 
           for image in "${images[@]}"; do
-            image_path="wikibase/${image}"
+            image_path="wmdetravisbot/${image}"
             url_run_id="ghcr.io/${{ github.repository_owner }}/${image_path}:dev-${{ github.run_id }}"
             version_tag="$(image_version $image)"
             docker tag "$url_run_id" "${image_path}:${version_tag}"

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -2,6 +2,10 @@ name: 📦 Build Test Tag and Publish Release
 
 on:
   pull_request:
+    types:
+      - closed
+    branches:
+      - "mw-*"
 
 permissions:
   contents: write
@@ -44,6 +48,9 @@ jobs:
           fi
 
   publish-dockerhub:
+    if: github.event.pull_request.merged == true
+
+    needs: tag-release
 
     runs-on: ubuntu-latest
 
@@ -66,14 +73,23 @@ jobs:
         run: |
           set -x
 
+          source ./variables.env
+          source ./versions.inc.sh
+
           docker image ls
 
           images=(
+            "wikibase"
+            "wikibase-bundle"
+            "elasticsearch"
+            "wdqs"
+            "wdqs-frontend"
             "wdqs-proxy"
+            "quickstatements"
           )
 
           for image in "${images[@]}"; do
-            image_path="wmdetravisbot/${image}"
+            image_path="wikibase/${image}"
             url_run_id="ghcr.io/${{ github.repository_owner }}/${image_path}:dev-${{ github.run_id }}"
             version_tag="$(image_version $image)"
             docker tag "$url_run_id" "${image_path}:${version_tag}"

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -89,9 +89,5 @@ jobs:
           )
 
           for image in "${images[@]}"; do
-            image_path="wikibase/${image}"
-            url_run_id="ghcr.io/${{ github.repository_owner }}/${image_path}:dev-${{ github.run_id }}"
-            version_tag="$(image_version $image)"
-            docker tag "$url_run_id" "${image_path}:${version_tag}"
-            docker push "${image_path}:${version_tag}"
+            echo "wikibase/${image}"
           done

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           set -x
 
-          source ./variables.env
-          source ./versions.inc.sh
-
           docker image ls
 
           images=(

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -2,8 +2,6 @@ name: 📦 Build Test Tag and Publish Release
 
 on:
   pull_request:
-    branches:
-      - "T358475-*"
 
 permissions:
   contents: write

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -66,8 +66,8 @@ jobs:
       - uses: docker/login-action@v3
         with:
           # implicitly docker hub
-          username: roti4wmde # TODO: get a bot user
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: wmdetravisbot
+          password: ${{ secrets.WBS_PUBLISH_TOKEN }}
 
       - name: Push release to dockerhub
         run: |

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -2,10 +2,7 @@ name: 📦 Build Test Tag and Publish Release
 
 on:
   pull_request:
-    types:
-      - closed
-    branches:
-      - "mw-*"
+
 
 permissions:
   contents: write
@@ -17,52 +14,14 @@ jobs:
 
     uses: ./.github/workflows/_build_test.yml
 
-  tag-release:
-    if: github.event.pull_request.merged == true
-
-    needs: _
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Git tag release
-        run: |
-          set -e # abort on error
-          set -x # show commands
-
-          set -o allexport
-          source ./variables.env
-
-          git config --global user.name 'wikibase suite github actions bot'
-          git config --global user.email 'wikibase-suite-github-actions-bot@users.noreply.github.com'
-
-          if git tag "$WMDE_RELEASE_VERSION"; then
-            git push --tags origin "$WMDE_RELEASE_VERSION"
-          else
-            echo "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***"
-            echo "Cannot tag $WMDE_RELEASE_VERSION, Most probably this tag is already given to another commit."
-            echo "Make sure to update the WMDE_RELEASE_VERSION variable in variables.env to publish a new release."
-            echo "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***"
-          fi
 
   publish-dockerhub:
-    if: github.event.pull_request.merged == true
-
-    needs: tag-release
 
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/pull-ghcr
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: docker/login-action@v3
         with:
           # implicitly docker hub

--- a/.github/workflows/build_test_publish_release.yml
+++ b/.github/workflows/build_test_publish_release.yml
@@ -2,7 +2,10 @@ name: 📦 Build Test Tag and Publish Release
 
 on:
   pull_request:
-
+    types:
+      - closed
+    branches:
+      - "mw-*"
 
 permissions:
   contents: write
@@ -14,23 +17,64 @@ jobs:
 
     uses: ./.github/workflows/_build_test.yml
 
+  tag-release:
+    if: github.event.pull_request.merged == true
+
+    needs: _
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Git tag release
+        run: |
+          set -e # abort on error
+          set -x # show commands
+
+          set -o allexport
+          source ./variables.env
+
+          git config --global user.name 'wikibase suite github actions bot'
+          git config --global user.email 'wikibase-suite-github-actions-bot@users.noreply.github.com'
+
+          if git tag "$WMDE_RELEASE_VERSION"; then
+            git push --tags origin "$WMDE_RELEASE_VERSION"
+          else
+            echo "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***"
+            echo "Cannot tag $WMDE_RELEASE_VERSION, Most probably this tag is already given to another commit."
+            echo "Make sure to update the WMDE_RELEASE_VERSION variable in variables.env to publish a new release."
+            echo "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***"
+          fi
 
   publish-dockerhub:
+    if: github.event.pull_request.merged == true
+
+    needs: tag-release
 
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
 
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/pull-ghcr
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/login-action@v3
         with:
           # implicitly docker hub
-          username: wmdetravisbot
-          password: ${{ secrets.WBS_PUBLISH_TOKEN }}
+          username: roti4wmde # TODO: get a bot user
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push release to dockerhub
         run: |
           set -x
+
+          source ./variables.env
+          source ./versions.inc.sh
 
           docker image ls
 
@@ -44,8 +88,10 @@ jobs:
             "quickstatements"
           )
 
-          echo "::debug::start listing images:"
           for image in "${images[@]}"; do
-            echo "::debug::wikibase/${image}"
+            image_path="wikibase/${image}"
+            url_run_id="ghcr.io/${{ github.repository_owner }}/${image_path}:dev-${{ github.run_id }}"
+            version_tag="$(image_version $image)"
+            docker tag "$url_run_id" "${image_path}:${version_tag}"
+            docker push "${image_path}:${version_tag}"
           done
-          echo "::debug::end images list"


### PR DESCRIPTION
Currently we are publishing our images to dockerhub using a personal account. We are changing the credentials for that personal account into a generic one.