### PR TITLE
Cleanup 1.40 test fragility

### DIFF
--- a/test/specs/confirm_edit/confirm-edit.ts
+++ b/test/specs/confirm_edit/confirm-edit.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 describe( 'ConfirmEdit', function () {
-	it( 'Should allow to edit with captcha', async () => {
+	it( 'Should allow to edit with captcha', async function () {
 		const executionResult = await browser.editPage(
 			testEnv.vars.WIKIBASE_URL,
 			'ConfirmEditTest',

--- a/test/specs/elasticsearch/elasticsearch.ts
+++ b/test/specs/elasticsearch/elasticsearch.ts
@@ -9,7 +9,7 @@ const itemLabel: string = getTestString( 'testItem' );
 describe( 'ElasticSearch', function () {
 	let itemId: string;
 
-	it( 'Should create an item', async () => {
+	it( 'Should create an item', async function () {
 		itemId = await WikibaseApi.createItem( itemLabel );
 
 		await ItemPage.open( itemId );
@@ -18,7 +18,7 @@ describe( 'ElasticSearch', function () {
 		);
 	} );
 
-	it( 'Should be able to set alias', async () => {
+	it( 'Should be able to set alias', async function () {
 		await browser.url( `${testEnv.vars.WIKIBASE_URL}/wiki/Special:SetAliases/` );
 
 		// input id
@@ -33,7 +33,7 @@ describe( 'ElasticSearch', function () {
 		await expect( $( '.wikibase-aliasesview-list-item' ) ).toHaveText( itemAlias );
 	} );
 
-	it( 'should be able to search case-insensitive', async () => {
+	it( 'should be able to search case-insensitive', async function () {
 		let searchResult: SearchResult[];
 
 		const testLabel = 'Testitem';

--- a/test/specs/fedprops/item.ts
+++ b/test/specs/fedprops/item.ts
@@ -13,7 +13,7 @@ describe( 'Fed props Item', function () {
 	const itemId = 'Q1';
 	const itemLabel = 'T267743-';
 
-	it( 'Should search wikidata.org through wbsearchentities with no local properties', async () => {
+	it( 'Should search wikidata.org through wbsearchentities with no local properties', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WIKIBASE_URL}/w/api.php?action=wbsearchentities&search=ISNI&format=json&language=en&type=property`
 		);
@@ -24,7 +24,7 @@ describe( 'Fed props Item', function () {
 		assert( searchResults.length > 0 );
 	} );
 
-	it( 'can add a federated property and it shows up in the ui', async () => {
+	it( 'can add a federated property and it shows up in the ui', async function () {
 		const data = {
 			claims: [
 				{
@@ -50,7 +50,7 @@ describe( 'Fed props Item', function () {
 		await SpecialEntityPage.addStatementLink;
 	} );
 
-	it( 'should NOT show up in Special:EntityData with ttl', async () => {
+	it( 'should NOT show up in Special:EntityData with ttl', async function () {
 		try {
 			await SpecialEntityDataPage.getData( 'Q1', 'ttl' );
 		} catch ( error ) {
@@ -59,7 +59,7 @@ describe( 'Fed props Item', function () {
 		}
 	} );
 
-	it( 'should show up in Special:EntityData with json', async () => {
+	it( 'should show up in Special:EntityData with json', async function () {
 		const data = await SpecialEntityDataPage.getData( 'Q1' );
 		assert.notEqual(
 			data.entities.Q1.claims[ 'http://www.wikidata.org/entity/P213' ],
@@ -67,7 +67,7 @@ describe( 'Fed props Item', function () {
 		);
 	} );
 
-	it( 'should NOT show up in Special:EntityData with rdf', async () => {
+	it( 'should NOT show up in Special:EntityData with rdf', async function () {
 		try {
 			await SpecialEntityDataPage.getData( 'Q1', 'rdf' );
 		} catch ( error ) {
@@ -76,7 +76,7 @@ describe( 'Fed props Item', function () {
 		}
 	} );
 
-	it( 'should NOT show property in queryservice ui after creation using prefixes', async () => {
+	it( 'should NOT show property in queryservice ui after creation using prefixes', async function () {
 		const prefixes = [ 'prefix fpwdt: <http://www.wikidata.org/prop/direct/>' ];
 		const query = `SELECT * WHERE{ ?s fpwdt:${propertyId} ?o }`;
 
@@ -98,7 +98,7 @@ describe( 'Fed props Item', function () {
 		);
 	} );
 
-	it( 'should NOT show up in queryservice ui after creation', async () => {
+	it( 'should NOT show up in queryservice ui after creation', async function () {
 		// query the item using wd: prefix
 		await QueryServiceUIPage.open( `SELECT * WHERE{ wd:${itemId} ?p ?o }` );
 

--- a/test/specs/fedprops/prefetching.ts
+++ b/test/specs/fedprops/prefetching.ts
@@ -8,7 +8,7 @@ describe( 'Property Prefetching', function () {
 	const itemLabel = 'T267743-';
 	const NUM_PROPERTIES = 25;
 
-	it( 'can add many federated properties and it shows up in the ui', async () => {
+	it( 'can add many federated properties and it shows up in the ui', async function () {
 		await browser.url(
 			'https://www.wikidata.org/wiki/Special:ListProperties?datatype=string'
 		);
@@ -45,7 +45,7 @@ describe( 'Property Prefetching', function () {
 		);
 	} );
 
-	it( 'should delete all statements and generate individual changes', async () => {
+	it( 'should delete all statements and generate individual changes', async function () {
 		const statements = await $$( '.wikibase-statementview' );
 		const propertyGuids = await Promise.all(
 			statements.map( async ( statement ) => statement.getAttribute( 'id' ) )
@@ -63,7 +63,7 @@ describe( 'Property Prefetching', function () {
 		await browser.pause( 2000 );
 	} );
 
-	it( 'Should render history page list within threshold', async () => {
+	it( 'Should render history page list within threshold', async function () {
 		await ItemPage.open( itemId, { action: 'history' } );
 		await $( '#pagehistory' );
 
@@ -74,7 +74,7 @@ describe( 'Property Prefetching', function () {
 		);
 	} );
 
-	it( 'Should render recent changes list within threshold', async () => {
+	it( 'Should render recent changes list within threshold', async function () {
 		await browser.url(
 			`${testEnv.vars.WIKIBASE_URL}/wiki/Special:RecentChanges?limit=50&days=7&urlversion=2&enhanced=0`
 		);

--- a/test/specs/pingback/pingback.ts
+++ b/test/specs/pingback/pingback.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 describe( 'Pingback', function () {
-	it( 'Should ping on first page request', async () => {
+	it( 'Should ping on first page request', async function () {
 		await browser.url( testEnv.vars.WIKIBASE_URL + '/wiki/Main_Page' );
 
 		// eslint-disable-next-line wdio/no-pause

--- a/test/specs/quickstatements/quickstatements.ts
+++ b/test/specs/quickstatements/quickstatements.ts
@@ -58,12 +58,12 @@ describe( 'QuickStatements Service', function () {
 	let propertyIdItem = null;
 	let propertyURL = null;
 
-	it( 'Should be able to load the start page', async () => {
+	it( 'Should be able to load the start page', async function () {
 		await browser.url( testEnv.vars.QUICKSTATEMENTS_URL );
 		await $( 'body' ).$( 'p*=QuickStatements is a tool' );
 	} );
 
-	it( 'Should be able to log in', async () => {
+	it( 'Should be able to log in', async function () {
 		await browser.url(
 			`${testEnv.vars.QUICKSTATEMENTS_URL}/api.php?action=oauth_redirect`
 		);
@@ -92,14 +92,14 @@ describe( 'QuickStatements Service', function () {
 		await expect( $( 'nav.navbar' ) ).toHaveTextContaining( 'QuickStatements' );
 	} );
 
-	it( 'Should be able to click batch button and be taken to the next page', async () => {
+	it( 'Should be able to click batch button and be taken to the next page', async function () {
 		await browser.url( `${testEnv.vars.QUICKSTATEMENTS_URL}/#` );
 		await $( 'a[tt="new_batch"]=New batch' ).click();
 
 		await expect( $( 'span=Create new command batch for' ) ).toExist();
 	} );
 
-	it( 'Should be able to create two items', async () => {
+	it( 'Should be able to create two items', async function () {
 		await browser.url( `${testEnv.vars.QUICKSTATEMENTS_URL}/#/batch` );
 
 		await browser.executeQuickStatement( 'CREATE\nCREATE' );
@@ -111,7 +111,7 @@ describe( 'QuickStatements Service', function () {
 		assert.strictEqual( responseQ2Data.entities.Q2.id, 'Q2' );
 	} );
 
-	it( 'Should be able to create item with label', async () => {
+	it( 'Should be able to create item with label', async function () {
 		await browser.url( `${testEnv.vars.QUICKSTATEMENTS_URL}/#/batch` );
 
 		await browser.executeQuickStatement( 'CREATE\nLAST|Len|"Best label"' );
@@ -124,7 +124,7 @@ describe( 'QuickStatements Service', function () {
 		);
 	} );
 
-	it( 'Should be able to create an item with statement', async () => {
+	it( 'Should be able to create an item with statement', async function () {
 		await browser.url( `${testEnv.vars.QUICKSTATEMENTS_URL}/#/batch` );
 
 		const stringPropertyId = await WikibaseApi.createProperty( 'string' );
@@ -140,7 +140,7 @@ describe( 'QuickStatements Service', function () {
 		).toBe( 'slippery fish' );
 	} );
 
-	it( 'Should be able to add an alias to an item', async () => {
+	it( 'Should be able to add an alias to an item', async function () {
 		await browser.executeQuickStatement( 'Q1|ASv|"Kommer det funka?"' );
 
 		// go look at wikibase
@@ -149,7 +149,7 @@ describe( 'QuickStatements Service', function () {
 		assert( lodash.isEmpty( responseQ1Data.entities.Q1.aliases ) !== true );
 	} );
 
-	it( 'Should be able to add a label to an item', async () => {
+	it( 'Should be able to add a label to an item', async function () {
 		await browser.executeQuickStatement( 'Q1|LSv|"Some label"' );
 
 		// go look at wikibase
@@ -158,7 +158,7 @@ describe( 'QuickStatements Service', function () {
 		assert( lodash.isEmpty( responseQ1Data.entities.Q1.labels ) !== true );
 	} );
 
-	it( 'Should be able to add a description to an item', async () => {
+	it( 'Should be able to add a description to an item', async function () {
 		await browser.executeQuickStatement( 'Q1|DSv|"Kommer det funka?"' );
 
 		// go look at wikibase
@@ -167,7 +167,7 @@ describe( 'QuickStatements Service', function () {
 		assert( lodash.isEmpty( responseQ1Data.entities.Q1.descriptions ) !== true );
 	} );
 
-	it.skip( 'Should be able to add a sitelink to an item', async () => {
+	it.skip( 'Should be able to add a sitelink to an item', async function () {
 		await browser.executeQuickStatement( 'Q1|Sclient_wiki|"Main_Page"' );
 
 		// go look at wikibase
@@ -176,7 +176,7 @@ describe( 'QuickStatements Service', function () {
 		assert( lodash.isEmpty( responseQ1Data.entities.Q1.sitelinks ) !== true );
 	} );
 
-	it( 'Should be able to add a statement to an item', async () => {
+	it( 'Should be able to add a statement to an item', async function () {
 		propertyId = await WikibaseApi.getProperty( 'string' );
 
 		await browser.executeQuickStatement( `Q1|${propertyId}|"Will it blend?"` );
@@ -192,12 +192,12 @@ describe( 'QuickStatements Service', function () {
 		);
 	} );
 
-	describe( 'Should be able to add qualifiers to statements with a range of datatypes', () => {
+	describe( 'Should be able to add qualifiers to statements with a range of datatypes', function () {
 		// should be disabled for dynamic tests
 		// eslint-disable-next-line mocha/no-setup-in-describe
 		mainSnakDataTypes.forEach( ( mainSnakDataType ) => {
 			qualifierSnakDataTypes.forEach( ( qualifierSnakDataType ) => {
-				it( `Should be able to add a ${mainSnakDataType} statement with a ${qualifierSnakDataType} qualifier.`, async () => {
+				it( `Should be able to add a ${mainSnakDataType} statement with a ${qualifierSnakDataType} qualifier.`, async function () {
 					const itemId = await WikibaseApi.createItem( 'qualifier-item', {} );
 
 					const mainPropertyId =
@@ -221,7 +221,7 @@ describe( 'QuickStatements Service', function () {
 		} );
 	} );
 
-	it( 'Should be able to add statement with qualifiers', async () => {
+	it( 'Should be able to add statement with qualifiers', async function () {
 		propertyIdItem = await WikibaseApi.getProperty( 'wikibase-item' );
 
 		await browser.executeQuickStatement(
@@ -235,7 +235,7 @@ describe( 'QuickStatements Service', function () {
 		);
 	} );
 
-	it( 'Should be able to add a property with "wikibase-item" reference', async () => {
+	it( 'Should be able to add a property with "wikibase-item" reference', async function () {
 		const itemId = await WikibaseApi.createItem( 'reference-item', {} );
 
 		propertyIdItem = await WikibaseApi.getProperty( 'wikibase-item' );
@@ -257,7 +257,7 @@ describe( 'QuickStatements Service', function () {
 		assert.strictEqual( refValue.id, 'Q2' );
 	} );
 
-	it( 'Should be able to add a property with "url" reference', async () => {
+	it( 'Should be able to add a property with "url" reference', async function () {
 		const itemId = await WikibaseApi.createItem( 'reference-url', {} );
 		propertyURL = await WikibaseApi.getProperty( 'url' );
 		const url = '"https://www.wikidata.org"';
@@ -275,7 +275,7 @@ describe( 'QuickStatements Service', function () {
 		assert.strictEqual( refValue, 'https://www.wikidata.org' );
 	} );
 
-	it( 'Should be able to add a property with "string" reference', async () => {
+	it( 'Should be able to add a property with "string" reference', async function () {
 		const itemId = await WikibaseApi.createItem( 'reference-string', {} );
 		const stringValue = '"some string"';
 		const propertyNumber = propertyId.replace( 'P', '' );
@@ -291,7 +291,7 @@ describe( 'QuickStatements Service', function () {
 		assert.strictEqual( refValue, 'some string' );
 	} );
 
-	it( 'Should be able to add and remove a property on an item', async () => {
+	it( 'Should be able to add and remove a property on an item', async function () {
 		const itemId = await WikibaseApi.createItem( 'add-remove', {} );
 
 		await browser.executeQuickStatement( `${itemId}|${propertyIdItem}|Q1` );
@@ -311,7 +311,7 @@ describe( 'QuickStatements Service', function () {
 		);
 	} );
 
-	it( 'Should be able to change label', async () => {
+	it( 'Should be able to change label', async function () {
 		await browser.executeQuickStatement( 'Q1|LSv|"Some other label"' );
 
 		const responseQ1Data = await SpecialEntityDataPage.getData( 'Q1' );
@@ -321,7 +321,7 @@ describe( 'QuickStatements Service', function () {
 		);
 	} );
 
-	it( 'Should be able to merge two items', async () => {
+	it( 'Should be able to merge two items', async function () {
 		await browser.url( `${testEnv.vars.QUICKSTATEMENTS_URL}/#/batch` );
 
 		await browser.executeQuickStatement( 'MERGE|Q1|Q2' );
@@ -330,7 +330,7 @@ describe( 'QuickStatements Service', function () {
 		assert.strictEqual( responseQ2Data.entities.Q1.id, 'Q1' );
 	} );
 
-	it( 'Should have a Last Batches button', async () => {
+	it( 'Should have a Last Batches button', async function () {
 		await browser.url( `${testEnv.vars.QUICKSTATEMENTS_URL}/#/batch` );
 
 		await $( 'a[tt="show_your_last_batches"]=Your last batches' ).click();

--- a/test/specs/repo/api.ts
+++ b/test/specs/repo/api.ts
@@ -9,7 +9,7 @@ const dataTypes = [ wikibasePropertyString ];
 describe( 'Wikibase API', function () {
 	// eslint-disable-next-line mocha/no-setup-in-describe
 	dataTypes.forEach( ( dataType: WikibasePropertyType ) => {
-		it( `Should be able to create many properties and items of type ${dataType.name}`, async () => {
+		it( `Should be able to create many properties and items of type ${dataType.name}`, async function () {
 			Array( 100 ).forEach( async () => {
 				const itemLabel = 'T267743-';
 				const propertyValue = `PropertyExample${dataType.name}Value`;

--- a/test/specs/repo/extensions/babel.ts
+++ b/test/specs/repo/extensions/babel.ts
@@ -6,7 +6,7 @@ describe( 'Babel', function () {
 		await browser.skipIfExtensionNotPresent( this, 'Babel' );
 	} );
 
-	it( 'Should be able to update the user page with language skills', async () => {
+	it( 'Should be able to update the user page with language skills', async function () {
 		await LoginPage.login( testEnv.vars.MW_ADMIN_NAME, testEnv.vars.MW_ADMIN_PASS );
 
 		const executionContent = await browser.editPage(

--- a/test/specs/repo/extensions/entityschema.ts
+++ b/test/specs/repo/extensions/entityschema.ts
@@ -10,7 +10,7 @@ describe( 'EntitySchema', function () {
 		await browser.skipIfExtensionNotPresent( this, 'EntitySchema' );
 	} );
 
-	it( 'Should be able to create an EntitySchema', async () => {
+	it( 'Should be able to create an EntitySchema', async function () {
 		await browser.url( testEnv.vars.WIKIBASE_URL + '/wiki/EntitySchema:test' );
 
 		// gives the link to Special:NewEntitySchema

--- a/test/specs/repo/extensions/scribunto.ts
+++ b/test/specs/repo/extensions/scribunto.ts
@@ -7,7 +7,7 @@ describe( 'Scribunto', function () {
 		await browser.skipIfExtensionNotPresent( this, 'Scribunto' );
 	} );
 
-	it( 'Should be able to execute lua module', async () => {
+	it( 'Should be able to execute lua module', async function () {
 		// eslint-disable-next-line security/detect-non-literal-fs-filename
 		const fileContents = await readFile( new URL( 'bananas.lua', import.meta.url ), utf8 );
 		await browser.editPage(
@@ -26,7 +26,7 @@ describe( 'Scribunto', function () {
 		assert( executionContent.includes( 'Hello, world!' ) );
 	} );
 
-	it( 'Should be able to execute lua module within 0.05 seconds', async () => {
+	it( 'Should be able to execute lua module within 0.05 seconds', async function () {
 		const cpuTime = await browser.getLuaCpuTime(
 			testEnv.vars.WIKIBASE_URL,
 			'LuaTest'

--- a/test/specs/repo/extensions/syntax-highlight.ts
+++ b/test/specs/repo/extensions/syntax-highlight.ts
@@ -7,7 +7,7 @@ describe( 'SyntaxHighlight', function () {
 		await browser.skipIfExtensionNotPresent( this, 'SyntaxHighlight' );
 	} );
 
-	it( 'Should highlight lua script', async () => {
+	it( 'Should highlight lua script', async function () {
 		// eslint-disable-next-line security/detect-non-literal-fs-filename
 		const fileContents = await readFile( new URL( 'bananas.lua', import.meta.url ), utf8 );
 

--- a/test/specs/repo/extensions/universal-language-selector.ts
+++ b/test/specs/repo/extensions/universal-language-selector.ts
@@ -5,7 +5,7 @@ describe( 'UniversalLanguageSelector', function () {
 		await browser.skipIfExtensionNotPresent( this, 'UniversalLanguageSelector' );
 	} );
 
-	it( 'Should be able to see the language selector menu', async () => {
+	it( 'Should be able to see the language selector menu', async function () {
 		await browser.url( testEnv.vars.WIKIBASE_URL );
 		await $( '#searchInput' ).click();
 		await $( '.imeselector' ).click();

--- a/test/specs/repo/extensions/visual-editor.ts
+++ b/test/specs/repo/extensions/visual-editor.ts
@@ -5,7 +5,7 @@ describe( 'VisualEditor', function () {
 		await browser.skipIfExtensionNotPresent( this, 'VisualEditor' );
 	} );
 
-	it( 'Should be able to edit a page using the editor', async () => {
+	it( 'Should be able to edit a page using the editor', async function () {
 		await browser.url(
 			testEnv.vars.WIKIBASE_URL + '/wiki/TestVisualEditor?veaction=edit'
 		);

--- a/test/specs/repo/extensions/wikibase-edtf.ts
+++ b/test/specs/repo/extensions/wikibase-edtf.ts
@@ -9,7 +9,7 @@ describe( 'WikibaseEdtf', function () {
 		await browser.skipIfExtensionNotPresent( this, 'Wikibase EDTF' );
 	} );
 
-	it( 'Should allow to create and use the EDTF property', async () => {
+	it( 'Should allow to create and use the EDTF property', async function () {
 		// create the property
 		const propertyId = await WikibaseApi.createProperty( 'edtf' );
 		assert.strictEqual( propertyId.startsWith( 'P' ), true );
@@ -44,7 +44,7 @@ describe( 'WikibaseEdtf', function () {
 		await ItemPage.open( itemId );
 	} );
 
-	it( 'Should allow to create and use the EDTF property in UI', async () => {
+	it( 'Should allow to create and use the EDTF property in UI', async function () {
 		// create the property
 		await SpecialNewPropertyPage.open( { datatype: 'edtf' } );
 		await SpecialNewPropertyPage.labelInput.setValue( 'Groundhog Day Release' );

--- a/test/specs/repo/extensions/wikibase-local-media.ts
+++ b/test/specs/repo/extensions/wikibase-local-media.ts
@@ -14,7 +14,7 @@ describe( 'WikibaseLocalMedia', function () {
 		await browser.skipIfExtensionNotPresent( this, 'Wikibase Local Media' );
 	} );
 
-	it( 'Should allow to upload an image', async () => {
+	it( 'Should allow to upload an image', async function () {
 		await LoginPage.login(
 			testEnv.vars.MW_ADMIN_NAME,
 			testEnv.vars.MW_ADMIN_PASS
@@ -30,7 +30,7 @@ describe( 'WikibaseLocalMedia', function () {
 		await expect( $( '#firstHeading' ) ).toHaveText( 'File:Image.png' );
 	} );
 
-	it( 'Should allow to create a property with localMedia datatype', async () => {
+	it( 'Should allow to create a property with localMedia datatype', async function () {
 		propertyId = await WikibaseApi.createProperty( 'localMedia' );
 		assert.strictEqual( propertyId.startsWith( 'P' ), true );
 
@@ -40,7 +40,7 @@ describe( 'WikibaseLocalMedia', function () {
 		await expect( $( '#firstHeading' ) ).toHaveTextContaining( propertyId );
 	} );
 
-	it( 'Should allow to use uploaded image on statement', async () => {
+	it( 'Should allow to use uploaded image on statement', async function () {
 		const data: { claims: Claim[] } = {
 			claims: [
 				{
@@ -65,7 +65,7 @@ describe( 'WikibaseLocalMedia', function () {
 		assert.strictEqual( imageSource.includes( 'Image.png' ), true );
 	} );
 
-	it( 'Should allow to use uploaded image on statement in UI', async () => {
+	it( 'Should allow to use uploaded image on statement in UI', async function () {
 		const itemId = await WikibaseApi.createItem( 'image-test-2' );
 		await ItemPage.open( itemId );
 

--- a/test/specs/repo/extensions/wikibase-manifest.ts
+++ b/test/specs/repo/extensions/wikibase-manifest.ts
@@ -5,7 +5,7 @@ describe( 'WikibaseManifest', function () {
 		await browser.skipIfExtensionNotPresent( this, 'WikibaseManifest' );
 	} );
 
-	it( 'Should have rest endpoint and data', async () => {
+	it( 'Should have rest endpoint and data', async function () {
 		const result = await browser.makeRequest(
 			testEnv.vars.WIKIBASE_URL + '/w/rest.php/wikibase-manifest/v0/manifest'
 		);

--- a/test/specs/repo/property.ts
+++ b/test/specs/repo/property.ts
@@ -20,11 +20,11 @@ describe( 'Property', function () {
 	// eslint-disable-next-line mocha/no-setup-in-describe
 	dataTypes.forEach( ( dataType: WikibasePropertyType ) => {
 		// eslint-disable-next-line mocha/no-setup-in-describe
-		describe( `Should be able to work with type ${dataType.name}`, () => {
+		describe( `Should be able to work with type ${dataType.name}`, function () {
 			let propertyId: string = null;
 			let stringPropertyId: string = null;
 
-			before( async () => {
+			before( async function () {
 				propertyId = await WikibaseApi.createProperty( dataType.urlName );
 				stringPropertyId = await WikibaseApi.createProperty(
 					wikibasePropertyString.urlName
@@ -32,11 +32,11 @@ describe( 'Property', function () {
 				await browser.waitForJobs();
 			} );
 
-			beforeEach( async () => {
+			beforeEach( async function () {
 				await PropertyPage.open( propertyId );
 			} );
 
-			it( 'Should be able to add statement to property', async () => {
+			it( 'Should be able to add statement to property', async function () {
 				await $( '=add statement' ).click();
 				// fill out property id for statement
 				await browser.keys( stringPropertyId.split( '' ) );
@@ -53,7 +53,7 @@ describe( 'Property', function () {
 				);
 			} );
 
-			it( 'Should be able to add reference to property', async () => {
+			it( 'Should be able to add reference to property', async function () {
 				await $( '=add reference' ).click();
 				// fill out property id for reference
 				await $( '.ui-entityselector-input' ).isFocused();
@@ -80,21 +80,21 @@ describe( 'Property', function () {
 				await expect( reference.datavalue.value ).toEqual( referenceText );
 			} );
 
-			it( 'Should show changes in "View history" tab', async () => {
+			it( 'Should show changes in "View history" tab', async function () {
 				await $( '=View history' ).click();
 				await expect( $( '.comment*=Created claim' ) ).toExist();
 				await expect( $( '.comment*=Changed claim' ) ).toExist();
 				await expect( $( '.comment*=Created a new Property' ) ).toExist();
 			} );
 
-			it( 'Should display the added properties on the "Recent changes" page', async () => {
+			it( 'Should display the added properties on the "Recent changes" page', async function () {
 				await browser.waitForJobs();
 				await $( '=Recent changes' ).click();
 				await expect( $( `=(${propertyId})` ) ).toExist();
 				await expect( $( `=(${stringPropertyId})` ) ).toExist();
 			} );
 
-			it( 'Should be able to revert a change', async () => {
+			it( 'Should be able to revert a change', async function () {
 				await $( '=View history' ).click();
 				await expect(
 					( await $( 'ul.mw-contributions-list' ).$$( 'li' ) ).length
@@ -116,7 +116,7 @@ describe( 'Property', function () {
 				).toHaveTextContaining( undoSummaryText );
 			} );
 
-			it( 'Should be able to set label, description, aliases', async () => {
+			it( 'Should be able to set label, description, aliases', async function () {
 				await page.open( '/wiki/Special:SetLabelDescriptionAliases/' );
 				await $( 'label=ID:' ).click();
 				await browser.keys( propertyId.split( '' ) );

--- a/test/specs/repo/queryservice.ts
+++ b/test/specs/repo/queryservice.ts
@@ -6,8 +6,8 @@ import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 import QueryServiceUIPage from '../../helpers/pages/queryservice-ui/queryservice-ui.page.js';
 import { wikibasePropertyString } from '../../helpers/wikibase-property-types.js';
 
-describe( 'QueryService', () => {
-	it( 'Should not be able to post to sparql endpoint', async () => {
+describe( 'QueryService', function () {
+	it( 'Should not be able to post to sparql endpoint', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WDQS_PROXY_URL}/bigdata/namespace/wdq/sparql`,
 			{ validateStatus: false },
@@ -16,14 +16,14 @@ describe( 'QueryService', () => {
 		assert.strictEqual( result.status, 405 );
 	} );
 
-	it( 'Should be able to get sparql endpoint', async () => {
+	it( 'Should be able to get sparql endpoint', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WDQS_PROXY_URL}/bigdata/namespace/wdq/sparql`
 		);
 		assert.strictEqual( result.status, 200 );
 	} );
 
-	it( 'Should not be possible to reach blazegraph ldf api that is not enabled', async () => {
+	it( 'Should not be possible to reach blazegraph ldf api that is not enabled', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WDQS_PROXY_URL}/bigdata/namespace/wdq/ldf`,
 			{ validateStatus: false }
@@ -31,7 +31,7 @@ describe( 'QueryService', () => {
 		assert.strictEqual( result.status, 404 );
 	} );
 
-	it( 'Should not be possible to reach blazegraph ldf assets thats not enabled', async () => {
+	it( 'Should not be possible to reach blazegraph ldf assets thats not enabled', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WDQS_PROXY_URL}/bigdata/namespace/wdq/assets`,
 			{ validateStatus: false }
@@ -39,7 +39,7 @@ describe( 'QueryService', () => {
 		assert.strictEqual( result.status, 404 );
 	} );
 
-	it( 'Should not be possible to reach blazegraph workbench', async () => {
+	it( 'Should not be possible to reach blazegraph workbench', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WDQS_PROXY_URL}/bigdata/#query`,
 			{ validateStatus: false }
@@ -47,7 +47,7 @@ describe( 'QueryService', () => {
 		assert.strictEqual( result.status, 404 );
 	} );
 
-	it( 'Should show up with property in queryservice ui after creation', async () => {
+	it( 'Should show up with property in queryservice ui after creation', async function () {
 		const itemLabel = 'T267743-';
 		const propertyValue = 'PropertyExampleStringValue';
 
@@ -116,7 +116,7 @@ describe( 'QueryService', () => {
 		);
 	} );
 
-	it( 'Should not show up in queryservice ui after deletion', async () => {
+	it( 'Should not show up in queryservice ui after deletion', async function () {
 		// TODO make an item using the UI
 		const itemId = await WikibaseApi.createItem( getTestString( 'T267743-' ) );
 
@@ -153,7 +153,7 @@ describe( 'QueryService', () => {
 		assert( resultText.includes( 'wikibase:timestamp' ) );
 	} );
 
-	it( 'Should show results for a select query', async () => {
+	it( 'Should show results for a select query', async function () {
 		await QueryServiceUIPage.open( 'SELECT * where { ?a ?b ?c }' );
 		await QueryServiceUIPage.submit();
 		expect(
@@ -161,7 +161,7 @@ describe( 'QueryService', () => {
 		).toBeGreaterThan( 0 );
 	} );
 
-	it( 'Should show list of properties', async () => {
+	it( 'Should show list of properties', async function () {
 		await QueryServiceUIPage.open( `SELECT ?property ?propertyType ?propertyLabel ?propertyDescription ?propertyAltLabel WHERE {
 			?property wikibase:propertyType ?propertyType .
 			SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
@@ -188,7 +188,7 @@ describe( 'QueryService', () => {
 		).toBeGreaterThan( 0 );
 	} );
 
-	it( 'Should show a property connected to item', async () => {
+	it( 'Should show a property connected to item', async function () {
 		const propertyId = await WikibaseApi.createProperty(
 			wikibasePropertyString.urlName
 		);

--- a/test/specs/repo/recent-changes.ts
+++ b/test/specs/repo/recent-changes.ts
@@ -1,11 +1,11 @@
 describe( 'Special:RecentChanges', function () {
-	beforeEach( async () => {
+	beforeEach( async function () {
 		await browser.url(
 			`${testEnv.vars.WIKIBASE_URL}/wiki/Special:RecentChanges?limit=50&days=7&urlversion=2&enhanced=0`
 		);
 	} );
 
-	it( 'Should be able to change limit', async () => {
+	it( 'Should be able to change limit', async function () {
 		await expect(
 			$( 'div.mw-rcfilters-ui-changesLimitAndDateButtonWidget' )
 		).toHaveTextContaining( '50 changes' );
@@ -18,7 +18,7 @@ describe( 'Special:RecentChanges', function () {
 		).toHaveTextContaining( '100 changes' );
 	} );
 
-	it( 'Should be able to change time to 2 hours', async () => {
+	it( 'Should be able to change time to 2 hours', async function () {
 		await expect(
 			$( 'div.mw-rcfilters-ui-changesLimitAndDateButtonWidget' )
 		).toHaveTextContaining( '7 days' );
@@ -29,7 +29,7 @@ describe( 'Special:RecentChanges', function () {
 		).toHaveTextContaining( '2 hours' );
 	} );
 
-	it( 'Should be able to change time to 3 days', async () => {
+	it( 'Should be able to change time to 3 days', async function () {
 		await expect(
 			$( 'div.mw-rcfilters-ui-changesLimitAndDateButtonWidget' )
 		).toHaveTextContaining( '7 days' );

--- a/test/specs/repo/search.ts
+++ b/test/specs/repo/search.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 
 describe( 'Search', function () {
-	it( 'Should be able to create an item and search for it', async () => {
+	it( 'Should be able to create an item and search for it', async function () {
 		const itemLabel = 'something';
 		await WikibaseApi.createItem( itemLabel, {} );
 

--- a/test/specs/repo/special-item.ts
+++ b/test/specs/repo/special-item.ts
@@ -3,7 +3,7 @@ import SpecialEntityPage from 'wdio-wikibase/pageobjects/item.page.js';
 import SpecialNewItemPage from '../../helpers/pages/special/new-item.page.js';
 
 describe( 'Special:NewItem', function () {
-	it( 'Should be able to create a new item', async () => {
+	it( 'Should be able to create a new item', async function () {
 		const label = 'Cool label';
 		const description = 'Cool description';
 		const firstAlias = 'Great job';

--- a/test/specs/repo/special-property.ts
+++ b/test/specs/repo/special-property.ts
@@ -27,7 +27,7 @@ describe( 'Special:NewProperty', function () {
 				}
 			} );
 
-			it( `Should be able to create a new property of datatype ${dataType.name}`, async () => {
+			it( `Should be able to create a new property of datatype ${dataType.name}`, async function () {
 				this.retries( 4 );
 
 				await SpecialNewPropertyPage.open();
@@ -55,7 +55,7 @@ describe( 'Special:NewProperty', function () {
 		} );
 	} );
 
-	it( 'Should be able to see newly created properties in list of properties special page', async () => {
+	it( 'Should be able to see newly created properties in list of properties special page', async function () {
 		await SpecialListPropertiesPage.open( {
 			dataType: wikibasePropertyString.urlName,
 			limit: 1000

--- a/test/specs/repo_client/extensions/scribunto-item.ts
+++ b/test/specs/repo_client/extensions/scribunto-item.ts
@@ -19,7 +19,7 @@ describe( 'Scribunto Item', function () {
 		await browser.skipIfExtensionNotPresent( this, 'Scribunto' );
 	} );
 
-	it( 'Should create an item on repo', async () => {
+	it( 'Should create an item on repo', async function () {
 		const propertyId = await WikibaseApi.createProperty( 'string' );
 		const data = {
 			claims: [
@@ -43,7 +43,7 @@ describe( 'Scribunto Item', function () {
 		);
 	} );
 
-	it( 'Should be able to reference an item on client using Lua', async () => {
+	it( 'Should be able to reference an item on client using Lua', async function () {
 		// eslint-disable-next-line security/detect-non-literal-fs-filename
 		const template = await readFile(
 			new URL( 'repo-client.lua', import.meta.url ),
@@ -71,7 +71,7 @@ describe( 'Scribunto Item', function () {
 	} );
 
 	// This will generate a change that will dispatch
-	it( 'Should be able to delete the item on repo', async () => {
+	it( 'Should be able to delete the item on repo', async function () {
 		await LoginPage.login(
 			testEnv.vars.MW_ADMIN_NAME,
 			testEnv.vars.MW_ADMIN_PASS
@@ -88,7 +88,7 @@ describe( 'Scribunto Item', function () {
 		await ItemPage.open( itemId );
 	} );
 
-	it.skip( 'Should be able to see delete changes is dispatched to client for lua page', async () => {
+	it.skip( 'Should be able to see delete changes is dispatched to client for lua page', async function () {
 		// eslint-disable-next-line wdio/no-pause
 		await browser.pause( 30 * 1000 );
 

--- a/test/specs/repo_client/interwiki-links.ts
+++ b/test/specs/repo_client/interwiki-links.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import { utf8 } from '../../helpers/readFileEncoding.js';
 
 describe( 'Interwiki links', function () {
-	it( 'Should be able to insert interwiki links', async () => {
+	it( 'Should be able to insert interwiki links', async function () {
 		// eslint-disable-next-line security/detect-non-literal-fs-filename
 		const repoLinkFile = await readFile(
 			new URL( 'interwiki-link.sql', import.meta.url ),

--- a/test/specs/repo_client/item.ts
+++ b/test/specs/repo_client/item.ts
@@ -15,12 +15,12 @@ describe( 'Item', function () {
 	const propertyValue = 'PropertyExampleStringValue';
 	const pageTitle = 'Test';
 
-	beforeEach( async () => {
+	beforeEach( async function () {
 		await browser.waitForJobs();
 		await browser.waitForJobs( testEnv.vars.WIKIBASE_CLIENT_URL );
 	} );
 
-	it( 'Special:NewItem should not be accessible on client', async () => {
+	it( 'Special:NewItem should not be accessible on client', async function () {
 		// Cannot use SpecialNewItemPage due to using WIKIBASE_CLIENT_URL
 		await browser.url(
 			`${testEnv.vars.WIKIBASE_CLIENT_URL}/wiki/Special:NewItem?uselang=qqx`
@@ -29,13 +29,13 @@ describe( 'Item', function () {
 		assert.strictEqual( notFoundText, '(nosuchspecialpage)' );
 	} );
 
-	it( 'Special:NewItem should be visible on repo', async () => {
+	it( 'Special:NewItem should be visible on repo', async function () {
 		await SpecialNewItemPage.open( { uselang: 'qqx' } );
 		const createNewItem = await SpecialNewItemPage.firstHeading.getText();
 		assert.strictEqual( createNewItem, '(special-newitem)' );
 	} );
 
-	it( 'Should create an item on repo', async () => {
+	it( 'Should create an item on repo', async function () {
 		propertyId = await WikibaseApi.createProperty( 'string' );
 		const data = {
 			claims: [
@@ -60,7 +60,7 @@ describe( 'Item', function () {
 	} );
 
 	// creates usage
-	it( 'Should be able to use the item on client with wikitext', async () => {
+	it( 'Should be able to use the item on client with wikitext', async function () {
 		const bodyText = await browser.editPage(
 			testEnv.vars.WIKIBASE_CLIENT_URL,
 			pageTitle,
@@ -72,7 +72,7 @@ describe( 'Item', function () {
 	} );
 
 	// This will generate a change that will dispatch
-	it( 'Should be able to create site-links from item to client', async () => {
+	it( 'Should be able to create site-links from item to client', async function () {
 		// Create a site-link on a the Main_Page
 		await browser.url(
 			`${testEnv.vars.WIKIBASE_URL}/wiki/Special:SetSiteLink/Q1?site=client_wiki&page=${pageTitle}`
@@ -88,7 +88,7 @@ describe( 'Item', function () {
 		assert( siteLinkValue.includes( pageTitle ) );
 	} );
 
-	it( 'Should be able to see site-link change is dispatched to client', async () => {
+	it( 'Should be able to see site-link change is dispatched to client', async function () {
 		const expectedSiteLinkChange: ExternalChange = {
 			type: 'external',
 			ns: 0,
@@ -105,7 +105,7 @@ describe( 'Item', function () {
 	} );
 
 	// This will generate a change that will dispatch
-	it( 'Should be able to delete the item on repo', async () => {
+	it( 'Should be able to delete the item on repo', async function () {
 		await LoginPage.login(
 			testEnv.vars.MW_ADMIN_NAME,
 			testEnv.vars.MW_ADMIN_PASS
@@ -122,7 +122,7 @@ describe( 'Item', function () {
 		await ItemPage.open( itemId );
 	} );
 
-	it.skip( 'Should be able to see delete changes is dispatched to client for test page', async () => {
+	it.skip( 'Should be able to see delete changes is dispatched to client for test page', async function () {
 		// eslint-disable-next-line wdio/no-pause
 		await browser.pause( 30 * 1000 );
 

--- a/test/specs/upgrade/pre-upgrade.ts
+++ b/test/specs/upgrade/pre-upgrade.ts
@@ -3,7 +3,7 @@ import { getTestString } from 'wdio-mediawiki/Util.js';
 import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 
 describe( 'Wikibase pre upgrade', function () {
-	it( 'Should be able to create many properties and items', async () => {
+	it( 'Should be able to create many properties and items', async function () {
 		const numEntities = 100;
 		for ( let i = 0; i < numEntities; i++ ) {
 			const itemLabel = 'T267743-';
@@ -33,7 +33,7 @@ describe( 'Wikibase pre upgrade', function () {
 		}
 	} );
 
-	it( 'Should be able to create a specific item', async () => {
+	it( 'Should be able to create a specific item', async function () {
 		const itemLabel = 'UpgradeItem';
 		const propertyValue = 'UpgradeItemStringValue';
 		const propertyId = await WikibaseApi.createProperty( 'string' );

--- a/test/specs/upgrade/queryservice-post-upgrade.ts
+++ b/test/specs/upgrade/queryservice-post-upgrade.ts
@@ -21,7 +21,7 @@ describe( 'Wikibase post upgrade', function () {
 		}
 	} );
 
-	it( 'Should be able to create a new specific item', async () => {
+	it( 'Should be able to create a new specific item', async function () {
 		newPropertyId = await WikibaseApi.createProperty( 'string' );
 		const data = {
 			claims: [
@@ -43,7 +43,7 @@ describe( 'Wikibase post upgrade', function () {
 		assert.strictEqual( newPropertyId.startsWith( 'P' ), true );
 	} );
 
-	it( 'New item should show up in Queryservice', async () => {
+	it( 'New item should show up in Queryservice', async function () {
 		let bindings: Binding[];
 
 		await browser.waitUntil(

--- a/test/specs/upgrade/queryservice-pre-and-post-upgrade.ts
+++ b/test/specs/upgrade/queryservice-pre-and-post-upgrade.ts
@@ -20,7 +20,7 @@ describe( 'Wikibase post upgrade', function () {
 		}
 	} );
 
-	it( 'Should be able find the item after upgrade', async () => {
+	it( 'Should be able find the item after upgrade', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WIKIBASE_URL}/w/api.php?action=wbsearchentities&search=UpgradeItem&format=json&language=en&type=item`
 		);
@@ -37,7 +37,7 @@ describe( 'Wikibase post upgrade', function () {
 		await ItemPage.open( oldItemID );
 	} );
 
-	it( 'Should show up in Special:EntityData with json', async () => {
+	it( 'Should show up in Special:EntityData with json', async function () {
 		const data = await SpecialEntityDataPage.getData( oldItemID );
 		const properties = Object.keys( data.entities[ oldItemID ].claims );
 
@@ -46,7 +46,7 @@ describe( 'Wikibase post upgrade', function () {
 		oldPropertyID = properties[ 0 ];
 	} );
 
-	it( 'Should show up in the Queryservice', async () => {
+	it( 'Should show up in the Queryservice', async function () {
 		let bindings: Binding[];
 
 		await browser.waitUntil(

--- a/test/specs/upgrade/upgrade.ts
+++ b/test/specs/upgrade/upgrade.ts
@@ -9,7 +9,7 @@ import { versions } from '../../suites/upgrade/versions.js';
 describe( 'Wikibase upgrade', function () {
 	let oldItemID: string;
 
-	before( async () => {
+	before( async function () {
 		// === Set image for current local build of wikibase
 		testEnv.vars.WIKIBASE_UPGRADE_TEST_IMAGE_URL =
 			versions[ process.env.TO_VERSION ];
@@ -41,7 +41,7 @@ describe( 'Wikibase upgrade', function () {
 		await testEnv.settings.before();
 	} );
 
-	it( 'Should be able to create many properties and items', async () => {
+	it( 'Should be able to create many properties and items', async function () {
 		const numEntities = 100;
 		for ( let i = 0; i < numEntities; i++ ) {
 			const itemLabel = 'T267743-';
@@ -70,7 +70,7 @@ describe( 'Wikibase upgrade', function () {
 		}
 	} );
 
-	it( 'Should be able find the item after upgrade', async () => {
+	it( 'Should be able find the item after upgrade', async function () {
 		const result = await browser.makeRequest(
 			`${testEnv.vars.WIKIBASE_URL}/w/api.php?action=wbsearchentities&search=UpgradeItem&format=json&language=en&type=item`
 		);
@@ -87,7 +87,7 @@ describe( 'Wikibase upgrade', function () {
 		await ItemPage.open( oldItemID );
 	} );
 
-	it( 'should show up in Special:EntityData with json', async () => {
+	it( 'should show up in Special:EntityData with json', async function () {
 		const data = await SpecialEntityDataPage.getData( oldItemID );
 		assert( data.entities[ oldItemID ].claims[ 0 ] !== null );
 	} );


### PR DESCRIPTION
Using `() => {}` instead of `function () {}` for tests means the context is incorrect, so things like `this.retries()` don't work.

We made this change to `main` a while ago - it never got down to mw-1.40