### PR TITLE
feat: tag quickstatements version

### DIFF
--- a/variables.env
+++ b/variables.env
@@ -178,11 +178,20 @@ WIKIBASEMANIFEST_COMMIT=5413c72af830a031fbf485b9c6b9e49057ac88c3
 WIKIBASELOCALMEDIA_COMMIT=b2aac56b81c25cd04708f1019a833c81f074a1f2
 # https://github.com/ProfessionalWiki/WikibaseEdtf/commits/master
 WIKIBASEEDTF_COMMIT=6e8ebf2818de4dd43a3f39d290e46a1626db1b22
+
+
+# ##############################################################################
+# Quickstatments
+# ##############################################################################
+# Updated automatically by ./build.sh update_hashes
 # https://github.com/magnusmanske/quickstatements/commits/master
 QUICKSTATEMENTS_COMMIT=c4b2c6b086b319aa32dcdd7a323edf188faaa66d
 # https://bitbucket.org/magnusmanske/magnustools/commits/branch/master
 MAGNUSTOOLS_COMMIT=5b8cea412000072a2c8753023c11472a4ac11ef5
 WBS_QUICKSTATEMENTS_VERSION=1.0.0
+# Quickstatements is currently considered version 2
+# https://www.wikidata.org/wiki/Help:QuickStatements#Running_QuickStatements
+QUICKSTATEMENTS_VERSION=2
 
 
 # ##############################################################################

--- a/versions.inc.sh
+++ b/versions.inc.sh
@@ -51,6 +51,8 @@ function version_tags() {
         tags+=("${WBS_ELASTICSEARCH_VERSION}-es${ELASTICSEARCH_VERSION}")
     elif [[ "$image_name" == "wdqs" ]]; then
         tags+=("${WBS_WDQS_VERSION}-wdqs${WDQS_VERSION}")
+    elif [[ "$image_name" == "quickstatements" ]]; then
+        tags+=("${WBS_QUICKSTATEMENTS_VERSION}-qs${QUICKSTATEMENTS_VERSION}")
     fi
 
     printf "%s\n" "${tags[@]}"


### PR DESCRIPTION
Quickstatements exists in Version 1 and 2 ([ref](https://www.wikidata.org/wiki/Help:QuickStatements#Running_QuickStatements)) while Version 3 is being developed ([ref](https://meta.wikimedia.org/wiki/Software_Collaboration_for_Wikidata/Open_Call)).

This PR adds a "X.X.X-qs2" tag to our Quickstatement images to note the current upstream Quickstatements version.