### PR TITLE
Reduces repeated Traefik tags in Deploy docker-compose.yml

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.wikibase.rule=Host(`${WIKIBASE_PUBLIC_HOST}`)"
-      - "traefik.http.routers.wikibase.entrypoints=websecure"
-      - "traefik.http.routers.wikibase.tls.certresolver=letsencrypt"
     volumes:
       - ./config:/config
       - wikibase-image-data:/var/www/html/images
@@ -137,8 +135,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.wdqs-frontend.rule=Host(`${WDQS_FRONTEND_PUBLIC_HOST}`)"
-      - "traefik.http.routers.wdqs-frontend.entrypoints=websecure"
-      - "traefik.http.routers.wdqs-frontend.tls.certresolver=letsencrypt"
     environment:
       WDQS_HOST: wdqs-proxy
     healthcheck:
@@ -159,8 +155,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.quickstatements.rule=Host(`${QUICKSTATEMENTS_PUBLIC_HOST}`)"
-      - "traefik.http.routers.quickstatements.entrypoints=websecure"
-      - "traefik.http.routers.quickstatements.tls.certresolver=letsencrypt"
     environment:
       QUICKSTATEMENTS_PUBLIC_URL: https://${QUICKSTATEMENTS_PUBLIC_HOST}
       WIKIBASE_PUBLIC_URL: https://${WIKIBASE_PUBLIC_HOST}
@@ -181,6 +175,8 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.asdefault"
+      - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
       # Redirects all http request to https
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -173,11 +173,13 @@ services:
       # Basic setup
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      # http endpoint
       - "--entrypoints.web.address=:80"
+      # https endpoint
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.websecure.asdefault"
       - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
-      # Redirects all http request to https
+      # http to https redirect
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"


### PR DESCRIPTION
This is simply a reduction of noise in Deploy's Docker Compose file, but also intended as a small step towards isolating our Traefik configuration such that a user could turn it off or switch it out for their own Reverse Proxy service or custom Traefik configuration. 

I think this is better, with the only question of whether it goes out with the v1/2/3 releases.  

_If you have an opinion as to whether this should be moved into the release, please note that and why/why not in your review. Either way this will not be merged until there is a clear decision across the team._ 