### PR TITLE
T368373 (2): Skaffold-based builds POC (not CI integrated)

### DIFF
--- a/run_skaffold.sh
+++ b/run_skaffold.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o allexport
+# shellcheck disable=SC1091
+source ./variables.env
+if [ -f ./local.env ]; then
+    # shellcheck disable=SC1091
+    source ./local.env
+fi
+set +o allexport
+
+# skaffold build
+skaffold build -q --dry-run

--- a/skaffold.yml
+++ b/skaffold.yml
@@ -1,0 +1,99 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+
+build:
+  local:
+    push: false
+    concurrency: 6
+
+  tagPolicy:
+    inputDigest: {}
+
+  # Extracts and applies correct full version number tag, but cannot create multiple tags
+  # tagPolicy:
+  #   envTemplate:
+  #     template: "{{ env (printf \"WBS_%s_VERSION\" (.IMAGE_NAME | replace \"wikibase/\" \"\" | upper)) }}"
+
+  artifacts:
+    - image: wikibase/wikibase
+      context: ./build/Wikibase
+      docker:
+        buildArgs:
+          PHP_IMAGE_URL: "{{ .PHP_IMAGE_URL }}"
+          COMPOSER_IMAGE_URL: "{{ .COMPOSER_IMAGE_URL }}"
+          MEDIAWIKI_VERSION: "{{ .MEDIAWIKI_VERSION }}"
+          WIKIBASE_COMMIT: "{{ .WIKIBASE_COMMIT }}"
+          BABEL_COMMIT: "{{ .BABEL_COMMIT }}"
+          CLDR_COMMIT: "{{ .CLDR_COMMIT }}"
+          CIRRUSSEARCH_COMMIT: "{{ .CIRRUSSEARCH_COMMIT }}"
+          CONFIRMEDIT_COMMIT: "{{ .CONFIRMEDIT_COMMIT }}"
+          ELASTICA_COMMIT: "{{ .ELASTICA_COMMIT }}"
+          ENTITYSCHEMA_COMMIT: "{{ .ENTITYSCHEMA_COMMIT }}"
+          NUKE_COMMIT: "{{ .NUKE_COMMIT }}"
+          OAUTH_COMMIT: "{{ .OAUTH_COMMIT }}"
+          SCRIBUNTO_COMMIT: "{{ .SCRIBUNTO_COMMIT }}"
+          SYNTAXHIGHLIGHT_GESHI_COMMIT: "{{ .SYNTAXHIGHLIGHT_GESHI_COMMIT }}"
+          UNIVERSALLANGUAGESELECTOR_COMMIT: "{{ .UNIVERSALLANGUAGESELECTOR_COMMIT }}"
+          VISUALEDITOR_COMMIT: "{{ .VISUALEDITOR_COMMIT }}"
+          WIKIBASECIRRUSSEARCH_COMMIT: "{{ .WIKIBASECIRRUSSEARCH_COMMIT }}"
+          WIKIBASEMANIFEST_COMMIT: "{{ .WIKIBASEMANIFEST_COMMIT }}"
+          WIKIBASEEDTF_COMMIT: "{{ .WIKIBASEEDTF_COMMIT }}"
+          WIKIBASELOCALMEDIA_COMMIT: "{{ .WIKIBASELOCALMEDIA_COMMIT }}"
+      hooks:
+        after:
+          - command: ["./skaffold_tagging.sh"]
+
+    - image: wikibase/elasticsearch
+      context: ./build/Elasticsearch
+      docker:
+        buildArgs:
+          ELASTICSEARCH_IMAGE_URL: "{{ .ELASTICSEARCH_IMAGE_URL }}"
+          ELASTICSEARCH_PLUGIN_WIKIMEDIA_EXTRA: "{{ .ELASTICSEARCH_PLUGIN_WIKIMEDIA_EXTRA }}"
+          ELASTICSEARCH_PLUGIN_WIKIMEDIA_HIGHLIGHTER: "{{ .ELASTICSEARCH_PLUGIN_WIKIMEDIA_HIGHLIGHTER }}"
+      hooks:
+        after:
+          - command: ["./skaffold_tagging.sh"]
+
+    - image: wikibase/wdqs
+      context: ./build/WDQS
+      docker:
+        buildArgs:
+          DEBIAN_IMAGE_URL: "{{ .DEBIAN_IMAGE_URL }}"
+          JRE_IMAGE_URL: "{{ .JRE_IMAGE_URL }}"
+          WDQS_VERSION: "{{ .WDQS_VERSION }}"
+      hooks:
+        after:
+          - command: ["./skaffold_tagging.sh"]
+
+    - image: wikibase/wdqs-frontend
+      context: ./build/WDQS-frontend
+      docker:
+        buildArgs:
+          COMPOSER_IMAGE_URL: "{{ .COMPOSER_IMAGE_URL }}"
+          NGINX_IMAGE_URL: "{{ .NGINX_IMAGE_URL }}"
+          NODE_IMAGE_URL: "{{ .NODE_IMAGE_URL }}"
+          WDQSQUERYGUI_COMMIT: "{{ .WDQSQUERYGUI_COMMIT }}"
+      hooks:
+        after:
+          - command: ["./skaffold_tagging.sh"]
+
+    - image: wikibase/wdqs-proxy
+      context: ./build/WDQS-proxy
+      docker:
+        buildArgs:
+          NGINX_IMAGE_URL: "{{ .NGINX_IMAGE_URL }}"
+      hooks:
+        after:
+          - command: ["./skaffold_tagging.sh"]
+
+    - image: wikibase/quickstatements
+      context: ./build/QuickStatements
+      docker:
+        buildArgs:
+          COMPOSER_IMAGE_URL: "{{ .COMPOSER_IMAGE_URL }}"
+          PHP_IMAGE_URL: "{{ .PHP_IMAGE_URL }}"
+          QUICKSTATEMENTS_COMMIT: "{{ .QUICKSTATEMENTS_COMMIT }}"
+          MAGNUSTOOLS_COMMIT: "{{ .MAGNUSTOOLS_COMMIT }}"
+      hooks:
+        after:
+          - command: ["./skaffold_tagging.sh"]

--- a/skaffold_tagging.sh
+++ b/skaffold_tagging.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Extract image_name from SKAFFOLD_IMAGE
+image_repository="${SKAFFOLD_IMAGE%%/*}"
+image_name_and_tag="${SKAFFOLD_IMAGE#*/}"
+image_name="${image_name_and_tag%%:*}"
+
+# Get version tags for the image name
+source ./versions.inc.sh
+mapfile -t tags < <(version_tags "$image_name")
+# Tag the image with each version tag
+for tag in "${tags[@]}"; do
+    echo "Tagging image: $image_repository/$image_name:$tag"
+    docker tag "$SKAFFOLD_IMAGE" "$image_repository/$image_name:$tag"
+done


### PR DESCRIPTION
Summary:

This works fine, but after testing this and the [Docker Compose based builds](https://github.com/wmde/wikibase-release-pipeline/pull/733), this compose build setup seemed a clear winner in terms of clarify and offered no less function for our use case. That Docker Compose build setup will easily translate to a Skaffold configuration if we ever want/need to go this direction.