### PR TITLE
fix(deploy): wikibase waits for elasticserch

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     restart: unless-stopped
     ports:
       - 8880:80


### PR DESCRIPTION
On first lauch, wikibase needs to create indices in elasticsearch.

This patch models this dependency explicitly in order to prevent a race condition that lead to failures on Ubuntu 22.04 with docker-ce.

https://phabricator.wikimedia.org/T371162