### PR TITLE
docs(wdqs): details about the empty sync issue

### DIFF
--- a/build/WDQS/README.md
+++ b/build/WDQS/README.md
@@ -200,11 +200,11 @@ Hooking into the internal filesystem can extend the functionality of this image.
 
 ### Updater keeps restarting
 
-In some situations the WDQS Updater enters a restart loop, e.g. when restarted without containing any entities. So when you restart a fresh instance, you will encounter this issue.
+In some situations the WDQS Updater enters a restart loop, e.g., when restarted without containing any entities. When you restart a freshly installed instance, you will encounter this issue.
 
 A workaround is to start the updater once with manual `--init` `--start` parameters. This forces it to sync data from MediaWiki for the current day.
 
-In the Docker Compose example provided above, you might run the following. This will also fix the problem in a Wikibase Suite Deploy instance:
+In the Docker Compose example provided above, you might use the commands and instructions supplied below. This will also fix the problem in a Wikibase Suite Deploy instance.
 
 ```sh
 # Stop the stock updater
@@ -212,13 +212,14 @@ docker compose stop wdqs-updater
 
 # Start an updater with force sync settings
 docker compose run --rm wdqs-updater bash '/wdqs/runUpdate.sh -h http://"$WDQS_HOST":"$WDQS_PORT" -- --wikibaseUrl "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --conceptUri "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --entityNamespaces "$WDQS_ENTITY_NAMESPACES" --init --start $(date +%Y%m%d000000)'
+
 # As soon as you see "Sleeping for 10 secs" in the logs, press CTRL-C to stop it again
 
 # Start the stock updater again
 docker compose start wdqs-updater
 ```
 
-As soon as the updater synced the first entity from MediaWiki, the issue should disappear.
+As soon as the updater has synced the first entity from MediaWiki, the issue should disappear.
 
 ## Source
 

--- a/build/WDQS/README.md
+++ b/build/WDQS/README.md
@@ -200,15 +200,25 @@ Hooking into the internal filesystem can extend the functionality of this image.
 
 ### Updater keeps restarting
 
-In some situations the WDQS Updater enters a restart loop. A workaround is to start the updater once with manual `--init` `--start` parameters for the current day.
+In some situations the WDQS Updater enters a restart loop, e.g. when restarted without containing any entities. So when you restart a fresh instance, you will encounter this issue.
 
-In the Docker Compose example provided above, you might run:
+A workaround is to start the updater once with manual `--init` `--start` parameters. This forces it to sync data from MediaWiki for the current day.
+
+In the Docker Compose example provided above, you might run the following. This will also fix the problem in a Wikibase Suite Deploy instance:
 
 ```sh
+# Stop the stock updater
 docker compose stop wdqs-updater
+
+# Start an updater with force sync settings
 docker compose run --rm wdqs-updater bash '/wdqs/runUpdate.sh -h http://"$WDQS_HOST":"$WDQS_PORT" -- --wikibaseUrl "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --conceptUri "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --entityNamespaces "$WDQS_ENTITY_NAMESPACES" --init --start $(date +%Y%m%d000000)'
+# As soon as you see "Sleeping for 10 secs" in the logs, press CTRL-C to stop it again
+
+# Start the stock updater again
 docker compose start wdqs-updater
 ```
+
+As soon as the updater synced the first entity from MediaWiki, the issue should disappear.
 
 ## Source
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -322,6 +322,10 @@ It is possible to migrate an existing Wikibase installation to WBS Deploy. The g
  - Regenerate the WDQS database
  - Regenerate the Elasticsearch database
 
+### My WDQS Updater keeps crashing, what can I do?
+
+Check out the known issue in the [WDQS README](../build/WDQS/README.md#Known-issues). You might find your solution there.
+
 ### Do you recommend any VPS hosting providers?
 
 As of this writing, we can offer no specific recommendations for VPS providers to host Wikibase Suite. The suite has been tested successfully on various providers; as long as the [minimum technical requirements](#hardware) are met, it should run as expected.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -324,7 +324,7 @@ It is possible to migrate an existing Wikibase installation to WBS Deploy. The g
 
 ### My WDQS Updater keeps crashing, what can I do?
 
-Check out the known issue in the [WDQS README](../build/WDQS/README.md#Known-issues). You might find your solution there.
+Check out the known issue in the [WDQS README](../build/WDQS/README.md#Known-issues). You may find your solution there in the form of a workaround.
 
 ### Do you recommend any VPS hosting providers?
 


### PR DESCRIPTION
This adds some documentations about the issue where WDQS crashes when restarted with an empty database that never synced entities from MediaWiki.

https://phabricator.wikimedia.org/T354266