### PR TITLE
docs(deploy): clarify domain names

### DIFF
--- a/deploy/template.env
+++ b/deploy/template.env
@@ -11,7 +11,8 @@
 # Public hostname configuration.
 # These domain names for your Wikibase Suite services should be configured on
 # your DNS server to point to the public IP address of the server being
-# deployed to.
+# deployed to. Note that you need three distinct names, e.g. three different
+# subdomains. Otherwise the reverse proxy cannot route properly.
 WIKIBASE_PUBLIC_HOST=wikibase.example.com
 WDQS_FRONTEND_PUBLIC_HOST=wdqs-frontend.example.com
 QUICKSTATEMENTS_PUBLIC_HOST=quickstatements.example.com


### PR DESCRIPTION
Clearly state that the domain names need to be distinct. Otherwise traefik reverse proxy will run into routing issues.