### PR TITLE
fix(wdqs-frontend): do not link to wikidata querybuilder

### DIFF
--- a/build/wdqs-frontend/custom-config.json
+++ b/build/wdqs-frontend/custom-config.json
@@ -12,7 +12,10 @@
 			"pageTitle": "Wikidata:SPARQL_query_service/queries/examples",
 			"pagePathElement": "wiki/"
 		},
-		"urlShortener": "tinyurl"
+		"urlShortener": "tinyurl",
+		"query-builder": {
+			"server": "https://gerrit.wikimedia.org/g/wikidata/query-builder"
+		}
 	},
 	"brand": {
 		"title": "$BRAND_TITLE",


### PR DESCRIPTION
Low hanging fruit workaround for #664 