### PR TITLE
feat(deploy)!: set WDQS concept URI

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -98,6 +98,8 @@ services:
         hard: 32768
     volumes:
       - wdqs-data:/wdqs/data
+    environment:
+      WIKIBASE_PUBLIC_URL: https://${WIKIBASE_PUBLIC_HOST}
     healthcheck:
       test: curl --silent --fail localhost:9999/bigdata/namespace/wdq/sparql
       interval: 10s
@@ -117,6 +119,8 @@ services:
       nofile:
         soft: 32768
         hard: 32768
+    environment:
+      WIKIBASE_PUBLIC_URL: https://${WIKIBASE_PUBLIC_HOST}
 
   wdqs-proxy:
     image: wikibase/wdqs-proxy:1


### PR DESCRIPTION
Sets the WIKIBASE_CONCEPT_URI required by WDQS. #771

Related:
 - https://github.com/wmde/wikibase-release-pipeline/issues/385
 -  https://phabricator.wikimedia.org/T197682

BREAKING CHANGE: changes the concept URI used in WDQS