### PR TITLE
fix: drop privileges during docker build

### DIFF
--- a/build/wdqs/Dockerfile
+++ b/build/wdqs/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && \
 COPY --from=fetcher --chown=blazegraph:blazegraph /tmp/wdqs-service /wdqs
 
 RUN mkdir /var/log/wdqs && chown blazegraph /var/log/wdqs
+RUN mkdir /wdqs/data && chown blazegraph /wdqs/data
 
 # Don't set a memory limit otherwise bad things happen (OOMs)
 ENV MEMORY=""\
@@ -76,5 +77,7 @@ COPY --chown=blazegraph:blazegraph RWStore.properties allowlist.txt logback.xml 
 
 # TODO this shouldn't be needed, but CI currently doesnt check for the +x bit, which is why this line is here
 RUN chmod +x /wdqs/runUpdate.sh
+
+USER blazegraph
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/wdqs/README.md
+++ b/build/wdqs/README.md
@@ -210,7 +210,7 @@ In the Docker Compose example provided above, you might use the commands and ins
 docker compose stop wdqs-updater
 
 # Start an updater with force sync settings
-docker compose run --rm wdqs-updater bash '/wdqs/runUpdate.sh -h http://"$WDQS_HOST":"$WDQS_PORT" -- --wikibaseUrl "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --conceptUri "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --entityNamespaces "$WDQS_ENTITY_NAMESPACES" --init --start $(date +%Y%m%d000000)'
+docker compose run --rm wdqs-updater /wdqs/runUpdate.sh -h http://\$WDQS_HOST:\$WDQS_PORT -- --wikibaseUrl \$WIKIBASE_SCHEME://\$WIKIBASE_HOST --conceptUri \$WIKIBASE_SCHEME://\$WIKIBASE_HOST --entityNamespaces \$WDQS_ENTITY_NAMESPACES --init --start $(date +%Y%m%d000000)
 
 # As soon as you see "Sleeping for 10 secs" in the logs, press CTRL-C to stop it again
 

--- a/build/wdqs/entrypoint.sh
+++ b/build/wdqs/entrypoint.sh
@@ -4,11 +4,11 @@
 # Test if required environment variables have been set
 REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST WDQS_PORT)
 for i in "${REQUIRED_VARIABLES[@]}"; do
-    eval THISSHOULDBESET=\$"$i"
-    if [ -z "$THISSHOULDBESET" ]; then
+  eval THISSHOULDBESET=\$"$i"
+  if [ -z "$THISSHOULDBESET" ]; then
     echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
     exit 1;
-    fi
+  fi
 done
 
 set -eu
@@ -17,15 +17,5 @@ export BLAZEGRAPH_OPTS="${BLAZEGRAPH_EXTRA_OPTS} -DwikibaseHost=${WIKIBASE_HOST}
 export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
 
 envsubst < /templates/mwservices.json > /wdqs/mwservices.json
-chown blazegraph:blazegraph /wdqs/mwservices.json
 
-# The data directory should always be owned by the blazegraph user
-# This used to be owned by root (https://phabricator.wikimedia.org/T237248)
-if [ -d /wdqs/data/ ]; then
-  chown blazegraph:blazegraph -R /wdqs/data/
-fi
-
-# Start as the blazegraph user.
-# --preserve-environment does not preserve PATH, so we manually
-# set the PATH again. Java cannot be found otherwise.
-su --preserve-environment --command "export PATH=$PATH; $*" blazegraph
+exec $(echo "$@"| envsubst)


### PR DESCRIPTION
Until now, the WDQS image started as root. In the entrypoint priveleges were dropped and we switched to the "blazegraph" user. With this patch, we switch to the "blazegraph" user already during build. So the container always uses this user and does not start as root anymore.

This fixes some issues when running an interactive bash inside the container and simplifies the updater reset workaround.

https://phabricator.wikimedia.org/T362963