### PR TITLE
chore(pipeline): Remove extraneous DockerHub auth in Release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -42,12 +42,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@v3
-        with:
-          # implicitly docker hub
-          username: wmdetravisbot
-          password: ${{ secrets.WBS_PUBLISH_TOKEN }}
-
       - name: Create release
         run: |
           set -e # abort on error


### PR DESCRIPTION
A small thing. I had the DockerHub auth step in the Make Release workflow and it is now longer necessary. This removes it.