### PR TITLE
chore: bump wdqs to version 2

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       start_period: 2m
 
   wdqs:
-    image: wikibase/wdqs:1
+    image: wikibase/wdqs:2
     command: /runBlazegraph.sh
     depends_on:
       wikibase:


### PR DESCRIPTION
In order to finally release the fix from #771 to deploy users.

Could this be merged with #771?