### PR TITLE
feat: add welcome bot for new contributors

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,3 +1,5 @@
+# Replies to people who have created an issue on this repository for the first time.
+
 newIssueWelcomeComment: >
 
   Hi! 👋
@@ -7,17 +9,18 @@ newIssueWelcomeComment: >
   Your input is valuable in making our project better for everyone. If you have any questions, do not hesitate to ask. We're here to help and support you along the way!
 
   Here are a few links to get you started:
-  * [Documentation]()
-  * [Developer Guide/Contribution Guide]()
-  * [Telegram Community Channel]()
-  * [Phabricator Tickets]()
-  * [Contact form]()
-  * [Wikibase Mailing List]()
-  * [Wikibase Suite Team Mail]()
+  * [Documentation](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md)
+  * [Telegram Community Channel](https://t.me/+WBsf9-C9KPuMZCDT)
+  * [Phabricator Tickets](https://phabricator.wikimedia.org/project/board/5755/)
+  * [Contact form](https://wikiba.se/contact/)
+  * [Wikibase Mailing List](https://lists.wikimedia.org/postorius/lists/wikibaseug.lists.wikimedia.org/?source=post_page---------------------------)
+  * [Wikibase Suite Team Mail](wikibase-suite@wikimedia.de)
 
   Looking forward to collaborating with you. We will get back to you on this issue within the next 14 days. 😊
 
   Happy contributing! 🚀
+
+# Replies to people who have created a PR on this repository for the first time.
 
 newPRWelcomeComment: >
 
@@ -28,17 +31,18 @@ newPRWelcomeComment: >
   Your work helps make our project better, and we are here to support you. If you have any questions or need any guidance, please feel free to reach out. We are all here to help make this process as smooth as possible for you.
 
   Here are a few links you might want to check out:
-  * [Documentation]()
-  * [Developer Guide/Contribution Guide]()
-  * [Telegram Community Channel]()
-  * [Phabricator Tickets]()
-  * [Contact form]()
-  * [Wikibase Mailing List]()
-  * [Wikibase Suite Team Mail]()
+  * [Documentation](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md)
+  * [Telegram Community Channel](https://t.me/+WBsf9-C9KPuMZCDT)
+  * [Phabricator Tickets](https://phabricator.wikimedia.org/project/board/5755/)
+  * [Contact form](https://wikiba.se/contact/)
+  * [Wikibase Mailing List](https://lists.wikimedia.org/postorius/lists/wikibaseug.lists.wikimedia.org/?source=post_page---------------------------)
+  * [Wikibase Suite Team Mail](wikibase-suite@wikimedia.de)
   
   Looking forward to working with you on this and future contributions! We will get back to you on this PR within the next 14 days.😊
 
   Happy contributing! 🚀
+
+# Replies to people who have merged a PR on this repository for the first time.
 
 firstPRMergeComment: >
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -48,6 +48,6 @@ firstPRMergeComment: |
 
   Congratulations on merging your first pull request! We hope to see more of your contributions to Wikibase Suite. 
 
-  We would love to see you join our community on [Telegram]() if you haven't already.
+  * We would love to see you join our community on [Telegram](https://t.me/+WBsf9-C9KPuMZCDT) if you haven't already.
 
   See you very soon in the next contribution 🚀

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -44,10 +44,11 @@ newPRWelcomeComment: |
 
 # Replies to people who have merged a PR on this repository for the first time.
 
-firstPRMergeComment: |+
+firstPRMergeComment: |
 
   Congratulations on merging your first pull request! We hope to see more of your contributions to Wikibase Suite. 
 
   We would love to see you join our community on [Telegram]() if you haven't already.
 
   See you very soon in the next contribution 🚀
+  

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -44,7 +44,7 @@ newPRWelcomeComment: |
 
 # Replies to people who have merged a PR on this repository for the first time.
 
-firstPRMergeComment: |
+firstPRMergeComment: |+
 
   Congratulations on merging your first pull request! We hope to see more of your contributions to Wikibase Suite. 
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,49 @@
+newIssueWelcomeComment: >
+
+  Hi! 👋
+
+  Thank you so much for opening your first issue with us! 🎉 We are thrilled to have you here and really appreciate you taking the time to contribute.
+
+  Your input is valuable in making our project better for everyone. If you have any questions, do not hesitate to ask. We're here to help and support you along the way!
+
+  Here are a few links to get you started:
+  * [Documentation]()
+  * [Developer Guide/Contribution Guide]()
+  * [Telegram Community Channel]()
+  * [Phabricator Tickets]()
+  * [Contact form]()
+  * [Wikibase Mailing List]()
+  * [Wikibase Suite Team Mail]()
+
+  Looking forward to collaborating with you. We will get back to you on this issue within the next 14 days. 😊
+
+  Happy contributing! 🚀
+
+newPRWelcomeComment: >
+
+  Hi! 👋
+
+  Thank you so much for submitting your first pull request! 🎉 We are excited to see your contribution and really appreciate the effort you've put in.
+
+  Your work helps make our project better, and we are here to support you. If you have any questions or need any guidance, please feel free to reach out. We are all here to help make this process as smooth as possible for you.
+
+  Here are a few links you might want to check out:
+  * [Documentation]()
+  * [Developer Guide/Contribution Guide]()
+  * [Telegram Community Channel]()
+  * [Phabricator Tickets]()
+  * [Contact form]()
+  * [Wikibase Mailing List]()
+  * [Wikibase Suite Team Mail]()
+  
+  Looking forward to working with you on this and future contributions! We will get back to you on this PR within the next 14 days.😊
+
+  Happy contributing! 🚀
+
+firstPRMergeComment: >
+
+  Congratulations on merging your first pull request! We hope to see more of your contributions to Wikibase Suite. 
+
+  We would love to see you join our community on [Telegram]() if you haven't already.
+
+  See you very soon in the next contribution 🚀

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,6 @@
 # Replies to people who have created an issue on this repository for the first time.
 
-newIssueWelcomeComment: >
+newIssueWelcomeComment: |
 
   Hi! 👋
 
@@ -22,7 +22,7 @@ newIssueWelcomeComment: >
 
 # Replies to people who have created a PR on this repository for the first time.
 
-newPRWelcomeComment: >
+newPRWelcomeComment: |
 
   Hi! 👋
 
@@ -44,7 +44,7 @@ newPRWelcomeComment: >
 
 # Replies to people who have merged a PR on this repository for the first time.
 
-firstPRMergeComment: >
+firstPRMergeComment: |
 
   Congratulations on merging your first pull request! We hope to see more of your contributions to Wikibase Suite. 
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -51,4 +51,3 @@ firstPRMergeComment: |
   We would love to see you join our community on [Telegram]() if you haven't already.
 
   See you very soon in the next contribution 🚀
-  


### PR DESCRIPTION
Adds a welcome bot to the repository which welcomes new contributors and shares links with docs, community, etc.

GitHub has an option to add GitHub Apps to repositories. 'Welcome' is a [GitHub app](https://github.com/behaviorbot/welcome?installation_id=56797506&setup_action=install) that helps us automatically reply to first time contributors of the repository. We do this by adding a config.yml file.

Ticket: https://phabricator.wikimedia.org/T379163