### PR TITLE
fix: bump wdqs-updater version to 2 as well

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       start_period: 2m
 
   wdqs-updater:
-    image: wikibase/wdqs:1
+    image: wikibase/wdqs:2
     command: /runUpdate.sh
     depends_on:
       wdqs:


### PR DESCRIPTION
This is a follow up to #795 and #771.

Unfortunately the original bug https://phabricator.wikimedia.org/T376016 remains until we release this one as well.