### PR TITLE
fix: injected standard prefixes reference wikidata

### DIFF
--- a/build/wdqs/entrypoint.sh
+++ b/build/wdqs/entrypoint.sh
@@ -13,7 +13,7 @@ done
 
 set -eu
 
-export BLAZEGRAPH_OPTS="${BLAZEGRAPH_EXTRA_OPTS} -DwikibaseHost=${WIKIBASE_HOST}"
+export BLAZEGRAPH_OPTS="${BLAZEGRAPH_EXTRA_OPTS} -DwikibaseHost=${WIKIBASE_HOST} -DwikibaseConceptUri=${WIKIBASE_CONCEPT_URI}"
 export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
 
 envsubst < /templates/mwservices.json > /wdqs/mwservices.json

--- a/build/wdqs/entrypoint.sh
+++ b/build/wdqs/entrypoint.sh
@@ -13,7 +13,24 @@ done
 
 set -eu
 
-export BLAZEGRAPH_OPTS="${BLAZEGRAPH_EXTRA_OPTS} -DwikibaseHost=${WIKIBASE_HOST} -DwikibaseConceptUri=${WIKIBASE_CONCEPT_URI}"
+# Options provided to WDQS (blazegraph) when running as query service instance
+#
+# Note: We MUST not provide -DwikibaseHost=${WIKIBASE_HOST} here, otherwise
+# WDQS would re-use the wd: et al. prefixes for the local wikibase instance.
+# This is unintended, especially in the context of federation. wd: prefixes
+# should remain in place for referencing wikidata. The local instance should
+# choose its own prefixes, as described here: 
+# https://www.mediawiki.org/wiki/Wikibase/Wikibase.cloud/First_steps#View_your_data_using_the_Query_Service
+# Some further thoughts on prefixes: https://phabricator.wikimedia.org/T335448
+#
+# In other words, WDQS does not know about the hostname of the wiki it gets
+# its data from. Is is solely the task of the updater to feed data from the
+# wiki into the WDQS instance.
+export BLAZEGRAPH_OPTS="${BLAZEGRAPH_EXTRA_OPTS}"
+
+# Options provided when running as wdqs-updater
+#
+# Here we provide -DwikibaseHost to reference the wiki to poll updates from.
 export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
 
 envsubst < /templates/mwservices.json > /wdqs/mwservices.json

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -98,6 +98,8 @@ services:
         hard: 32768
     volumes:
       - wdqs-data:/wdqs/data
+    environment:
+      WIKIBASE_CONCEPT_URI: https://${WIKIBASE_PUBLIC_HOST}
     healthcheck:
       test: curl --silent --fail localhost:9999/bigdata/namespace/wdq/sparql
       interval: 10s

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -98,8 +98,6 @@ services:
         hard: 32768
     volumes:
       - wdqs-data:/wdqs/data
-    environment:
-      WIKIBASE_CONCEPT_URI: https://${WIKIBASE_PUBLIC_HOST}
     healthcheck:
       test: curl --silent --fail localhost:9999/bigdata/namespace/wdq/sparql
       interval: 10s


### PR DESCRIPTION
~~As reported in #798, default prefixes injected by WDQS did not align with the `WIKIBASE_CONCEPT_URI` setting added in #771. This PR fixes it.~~

As reported in #798, the "standard prefixes" injected by WDQS do not align with the WIKIBASE_CONCEPT_URI setting introduced in #771, nor do they match the corresponding values for Wikidata. Currently, the WDQS-injected "standard prefixes" (such as `wd:`) reference `http://wikidata/`, which is the internal hostname of the wikibase/mediawiki container within the Docker network.

Particularly in the context of federation, it is essential to maintain the "standard prefixes" for referencing Wikidata [1] [2]. To accommodate the local Wikibase instance, prefixes can be set inline, as is currently done on wikibase.cloud [2]. This pull request addresses this discrepancy and updates the "standard prefixes" to point to Wikidata. Additional context can be found in [3].


[1] https://www.mediawiki.org/wiki/Wikibase/Wikibase.cloud/First_steps#View_your_data_using_the_Query_Service
[2] https://phabricator.wikimedia.org/T335448
[3] https://phabricator.wikimedia.org/T379232

