### PR TITLE
T376243 Preparing for next Wikibase and Deploy 1 release (don't merge)

### DIFF
--- a/build/wikibase/build.env
+++ b/build/wikibase/build.env
@@ -5,7 +5,7 @@
 # Update only patch versions for security releases.
 # Choose latest version for major releases.
 # https://releases.wikimedia.org/mediawiki/
-MEDIAWIKI_VERSION=1.42.3
+MEDIAWIKI_VERSION=1.39.10
 
 # ##############################################################################
 # PHP Composer
@@ -41,26 +41,26 @@ DEBIAN_IMAGE_URL=debian:bookworm-slim
 # Versions in REL_ branches ensure compatibility with respective mediawiki versions.
 # Shouldn't require much of a review.
 #
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Wikibase/+/refs/heads/REL1_42
-WIKIBASE_COMMIT=fecce7406f974d5ef36b338ad4480b38976ae12b
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Babel/+/refs/heads/REL1_42
-BABEL_COMMIT=ec7f16b17b9c1719b16edbe54b6cf8bf5763503c
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/cldr/+/refs/heads/REL1_42
-CLDR_COMMIT=2c509997e2389527d2bb31790624f265a359d7cf
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/CirrusSearch/+/refs/heads/REL1_42
-CIRRUSSEARCH_COMMIT=00e92ea3e6e4a60e7a548d1081d68701bee95997
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Elastica/+/refs/heads/REL1_42
-ELASTICA_COMMIT=1e4a7195533b41d940fba8577b3258726b241aea
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/EntitySchema/+/refs/heads/REL1_42
-ENTITYSCHEMA_COMMIT=25756343362973b11ca8e40fe3fcd56398fcf3c5
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/OAuth/+/refs/heads/REL1_42
-OAUTH_COMMIT=1ba1e32436efe04c004279ec1556dd9c8d7e9bc7
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/UniversalLanguageSelector/+/refs/heads/REL1_42
-UNIVERSALLANGUAGESELECTOR_COMMIT=17bbc88f8b02ef6e656fa1b1b924f444318019a5
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseCirrusSearch/+/refs/heads/REL1_42
-WIKIBASECIRRUSSEARCH_COMMIT=fad4ff89e9684d4b10bd0208072a2d335982db74
-# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseManifest/+/refs/heads/REL1_42
-WIKIBASEMANIFEST_COMMIT=5413c72af830a031fbf485b9c6b9e49057ac88c3
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Wikibase/+/refs/heads/REL1_39
+WIKIBASE_COMMIT=9ee27f4cc990f56fef67bd5190028a8cfd276ad0
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Babel/+/refs/heads/REL1_39
+BABEL_COMMIT=fd08e8ad50d864b37c897d694b09047f045ae247
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/cldr/+/refs/heads/REL1_39
+CLDR_COMMIT=267da10f490aad6d6883c91a9eefff63ae3861ea
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/CirrusSearch/+/refs/heads/REL1_39
+CIRRUSSEARCH_COMMIT=c3bf11f993a99954506300a705d9772c5bdae60e
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Elastica/+/refs/heads/REL1_39
+ELASTICA_COMMIT=13b91fc23a8e1b12a128bb129610820df91127c9
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/EntitySchema/+/refs/heads/REL1_39
+ENTITYSCHEMA_COMMIT=6efbc70600d4149a77d1ea04b067b31365b4ff30
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/OAuth/+/refs/heads/REL1_39
+OAUTH_COMMIT=10ac97f761561b319ba6f9f5e327465a15433991
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/UniversalLanguageSelector/+/refs/heads/REL1_39
+UNIVERSALLANGUAGESELECTOR_COMMIT=5c7ab78bc55325cb1ee471d200470f42547bb193
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseCirrusSearch/+/refs/heads/REL1_39
+WIKIBASECIRRUSSEARCH_COMMIT=9b84e10f0d5c74c9f3b060d129de6813794aecdc
+# https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseManifest/+/refs/heads/REL1_39
+WIKIBASEMANIFEST_COMMIT=a9acda8d9f3e671e30fdf14c00570d1b06a763ab
 
 # ##############################################################################
 # Community maintained extensions
@@ -70,7 +70,7 @@ WIKIBASEMANIFEST_COMMIT=5413c72af830a031fbf485b9c6b9e49057ac88c3
 # with mediawiki versions has to be checked explicitly. Review carefully.
 #
 # https://github.com/ProfessionalWiki/WikibaseLocalMedia/commits/master
-WIKIBASELOCALMEDIA_COMMIT=558224b04f4045913c628518e9e4c44e1db89a49
+WIKIBASELOCALMEDIA_COMMIT=77b2555dbf6cf8268e0077c6f38225d6833ee731
 # https://github.com/ProfessionalWiki/WikibaseEdtf/commits/master
 WIKIBASEEDTF_COMMIT=82692fb0de7b03bdf9e0caede3fa2f4646926ef2
 

--- a/build/wikibase/package.json
+++ b/build/wikibase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wikibase",
-	"version": "3.0.2",
+	"version": "1.0.0",
 	"nx": {
 		"targets": {
 			"lint": {},

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # --------------------------------------------------
 
   wikibase:
-    image: wikibase/wikibase:3
+    image: wikibase/wikibase:1
     depends_on:
       mysql:
         condition: service_healthy
@@ -37,7 +37,7 @@ services:
       start_period: 5m
 
   wikibase-jobrunner:
-    image: wikibase/wikibase:3
+    image: wikibase/wikibase:1
     command: /jobrunner-entrypoint.sh
     depends_on:
       wikibase:

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "deploy",
-	"version": "3.0.3",
+	"version": "1.0.0",
 	"nx": {
 		"targets": {
 			"lint": {},


### PR DESCRIPTION
Changes relevant versions for wikibase and deploy.

Remaining tasks: 

- [ ] Update versions (1.0.2 for Wikibase, and 3.0.3 for Deploy?)
- [ ] Create appropriate CHANGELOG for Wikibase and Deploy. Look to existing 3.x `build/wikibase/CHANGELOG.md` and `deploy/CHANGELOG.md` still in this branch for source