### PR TITLE
adding elasticsearch as a dependency

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     restart: unless-stopped
     ports:
       - 8880:80


### PR DESCRIPTION
Used `git checkout deploy-3` as described here: https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md
and consistently ran into a race condition on `docker compose up` that had wikibase discovering that elasticsearch is not up yet (and therefore failing to initialize the indexes)