### PR TITLE
fix: set traefik restart policy to 'unless-stopped'

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -188,6 +188,7 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
       # Uncomment this line to only test ssl generation first, makes sure you don't run into letsencrypt rate limits
       # - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+    restart: unless-stopped
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
As reported in https://phabricator.wikimedia.org/T382200, traefik is the only service that remains stopped after a docker daemon restart (e.g. when rebooting the host). This change fixes traefik's restart policy to match the other services so that also traefik starts up automatically.