### PR TITLE
Add operating system dependencies for Mediawiki extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ RUN apt-get update && \
         git \
         curl \
         jq \
-        python3-pip \
+    	ghostscript imagemagick xpdf-utils \
+    	exiv2 libtiff-tools \
+    	ffmpeg \
+    	libvips-tools \
+    	python3-pip \
         python3-venv \
         && ln -sf /usr/bin/python3 /usr/bin/python \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
See https://phabricator.wikimedia.org/T393666

Except for extension:3D for which I still don't have a running code.
