### PR TITLE
feat(deploy): Adds dev-centric option for using local builds

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,0 +1,23 @@
+services:
+  wikibase:
+    image: wikibase/wikibase
+    pull_policy: never
+  wikibase-jobrunner:
+    image: wikibase/wikibase
+    pull_policy: never
+  elasticsearch:
+    image: wikibase/elasticsearch
+    pull_policy: never
+  wdqs:
+    image: wikibase/wdqs
+    pull_policy: never
+  wdqs-updater:
+    image: wikibase/wdqs
+    pull_policy: never
+  wdqs-frontend:
+    image: wikibase/wdqs-frontend
+    pull_policy: never
+  quickstatements:
+    image: wikibase/quickstatements
+    pull_policy: never
+  


### PR DESCRIPTION
## Add `docker-compose.dev.yml` for local build testing using Deploy

This PR adds a `docker-compose.dev.yml` override that removes all explicit image tags and sets `pull_policy: never`, allowing Compose to always use locally built images (implied `:latest`) without attempting to pull from a registry. This makes it easy to run the Deploy stack entirely from images you’ve built locally, without editing the main compose files.

This is a **dev-only** option intended for contributors who need to test local builds.  _Note: On ARM64 systems (like mine), this also provides a simple way to run the stack when no appropriate published images exist._

**Usage example:**
```bash
./nx run-many -t build
cd deploy
docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
```

_Note: Sorry about the ugly/annoying branch name, it was an accident._