### PR TITLE
Use SoftwareInfo mediawiki hook in suite and deploy

### DIFF
--- a/build/wikibase/LocalSettings.d/10_SoftwareInfo_Suite.php
+++ b/build/wikibase/LocalSettings.d/10_SoftwareInfo_Suite.php
@@ -1,0 +1,6 @@
+<?php
+
+$wgHooks['SoftwareInfo'][] = function( &$software ) {
+    $software['[https://www.mediawiki.org/wiki/Wikibase/Suite Wikibase Suite]'] = 'yes';
+    return true;
+};

--- a/deploy/config/SoftwareInfo.php
+++ b/deploy/config/SoftwareInfo.php
@@ -1,0 +1,6 @@
+<?php
+
+$wgHooks['SoftwareInfo'][] = function( &$software ) {
+    $software['[https://www.mediawiki.org/wiki/Wikibase/Suite/Deploy Wikibase Suite Deploy]'] = 'yes';
+    return true;
+};

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ./config:/config:z
       - ./config/extensions:/var/www/html/extensions/extensions:z
+      - ./config/SoftwareInfo.php:/var/www/html/LocalSettings.d/10_SoftwareInfo_Deploy.php:z
       - ./config/Extensions.php:/var/www/html/LocalSettings.d/90_UserDefinedExtensions.php:z
       - wikibase-image-data:/var/www/html/images
       - quickstatements-data:/quickstatements/data


### PR DESCRIPTION
This will allow identification of both suite and deploy
seperatly in future released, via tooling such as
the wikibase-metatdata scraper, and other scrapers
such as for wikibase.world.

This could be implemented as a configurable extension that
would then be included as part of suite and deploy, however
that seemed a bit over the top when I started, given
the implementation here is small.

[Bug: T411587](https://phabricator.wikimedia.org/T411587)
