### PR TITLE
chore(test): Moves Traefik off port 80 in test setup to avoid Deploy conflicts

### DIFF
--- a/test/suites/docker-compose.override.yml
+++ b/test/suites/docker-compose.override.yml
@@ -68,6 +68,8 @@ services:
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.asdefault"
       - "--providers.file.filename=/etc/traefik/dynamic.yml"
+    ports: !override
+      - 8081:80
     volumes:
       - ../../deploy/config/traefik-dynamic.yml:/etc/traefik/dynamic.yml:ro
     networks:


### PR DESCRIPTION
This changes the test-suite Traefik port mapping from 80 to 8081 so the repo test services can run at the same time as the local Deploy stack. Without this override, both stacks try to bind the same host port, which makes it awkward to manually verify behavior in Deploy while also running targeted automated tests locally.