### PR TITLE
feat: Include wikibaseType field in callback payload

### DIFF
--- a/build/wikibase/CHANGELOG.md
+++ b/build/wikibase/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.0.1 (2026-04-21)
+
+### 🩹 Fixes
+- Include the wikibaseType field inside the callback payload
+
 # 6.0.0 (2026-02-16)
 
 Upgrades to MediaWiki from 1.44 to 1.45 including updates to compatible packaged extensions

--- a/build/wikibase/callback.sh
+++ b/build/wikibase/callback.sh
@@ -64,6 +64,7 @@ fi
 
 PAYLOAD="{\"query\": \"mutation m { addWikibase(wikibaseInput: {\
       wikibaseName: \\\"$MW_WG_SERVER\\\", \
+      wikibaseType: \\\"SUITE"\\\,
       urls: {\
         baseUrl: \\\"$MW_WG_SERVER\\\", \
         articlePath: \\\"/wiki\\\", \

--- a/build/wikibase/callback.sh
+++ b/build/wikibase/callback.sh
@@ -64,7 +64,7 @@ fi
 
 PAYLOAD="{\"query\": \"mutation m { addWikibase(wikibaseInput: {\
       wikibaseName: \\\"$MW_WG_SERVER\\\", \
-      wikibaseType: \\\"SUITE"\\\,
+      wikibaseType: \\\"SUITE\\\", \
       urls: {\
         baseUrl: \\\"$MW_WG_SERVER\\\", \
         articlePath: \\\"/wiki\\\", \

--- a/build/wikibase/package.json
+++ b/build/wikibase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wikibase",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"nx": {
 		"targets": {
 			"lint": {},


### PR DESCRIPTION
As a follow up to [this change](https://github.com/wmde/wikibase-metadata/pull/147) on wikibase-metadata, this PR sets the `wikibaseType` field in the callback payload. This ensures that entries are categorized correctly in the metrics. 