### PR TITLE
feat(wikibase): disable anonymous writes by default

### DIFF
--- a/build/wikibase/Dockerfile
+++ b/build/wikibase/Dockerfile
@@ -225,6 +225,8 @@ COPY callback.sh /callback.sh
 COPY jobrunner-entrypoint.sh /jobrunner-entrypoint.sh
 COPY htaccess /var/www/html/.htaccess
 COPY LocalSettings.d LocalSettings.d
+COPY LocalSettings.MediaWiki.php /LocalSettings.MediaWiki.php
+COPY LocalSettings.Extensions.php /LocalSettings.Extensions.php
 COPY default-extra-install.sh /default-extra-install.sh
 COPY oauth.ini /templates/oauth.ini
 COPY LocalSettings.wbs.php /templates/LocalSettings.wbs.php

--- a/build/wikibase/LocalSettings.Extensions.php
+++ b/build/wikibase/LocalSettings.Extensions.php
@@ -1,0 +1,5 @@
+<?php
+
+foreach ( glob( '/var/www/html/LocalSettings.d/*.php' ) as $filename ) {
+	include $filename;
+}

--- a/build/wikibase/LocalSettings.MediaWiki.php
+++ b/build/wikibase/LocalSettings.MediaWiki.php
@@ -1,0 +1,26 @@
+<?php
+
+# JobRunner instance is assumed by default, so jobs on request is disabled
+$wgJobRunRate = 0;
+
+# File Uploads enabled by default
+$wgEnableUploads = true;
+
+# Logs
+# TODO: Explore simply logging to stdout/stderr so these appear in Docker logs
+$wgDebugLogGroups = array(
+	'resourceloader' => '/var/log/mediawiki/mw.resourceloader.log',
+	'exception' => '/var/log/mediawiki/mw.exception.log',
+	'error' => '/var/log/mediawiki/mw.error.log',
+	'fatal' => '/var/log/mediawiki/mw.fatal.log',
+);
+$wgDebugLogFile = '/var/log/mediawiki/mw.debug.log';
+
+$wgArticlePath = "/wiki/$1";
+
+# Disable anonymous write access by default while keeping anonymous read access.
+$wgGroupPermissions['*']['edit'] = false;
+$wgGroupPermissions['*']['createpage'] = false;
+$wgGroupPermissions['*']['createtalk'] = false;
+$wgGroupPermissions['*']['writeapi'] = false;
+$wgGroupPermissions['*']['createaccount'] = false;

--- a/build/wikibase/LocalSettings.wbs.php
+++ b/build/wikibase/LocalSettings.wbs.php
@@ -1,33 +1,17 @@
 <?php
 
-# JobRunner instance is assumed by default, so jobs on request is disabled
-$wgJobRunRate = 0;
+# Managed by the Wikibase image. DO NOT REMOVE OR MOVE THIS LINE.
+require_once '/LocalSettings.MediaWiki.php';
 
-# File Uploads enabled by default
-$wgEnableUploads = true;
+# Add MediaWiki configuration values here that must be set before bundled
+# extensions are loaded.
 
-# Logs
-# TODO: Explore simply logging to stdout/stderr so these appear in Docker logs
-$wgDebugLogGroups = array(
-	'resourceloader' => '/var/log/mediawiki/mw.resourceloader.log',
-	'exception' => '/var/log/mediawiki/mw.exception.log',
-	'error' => '/var/log/mediawiki/mw.error.log',
-	'fatal' => '/var/log/mediawiki/mw.fatal.log',
-);
-$wgDebugLogFile = '/var/log/mediawiki/mw.debug.log';
-
-$wgArticlePath = "/wiki/$1";
-
-# Add configuration values here or above which should be set before extensions are loaded
-
-# Load extensions if present, alphabetically ordered by filename
-foreach (glob("LocalSettings.d/*.php") as $filename)
-{
-	include $filename;
-}
+# Managed by the Wikibase image. DO NOT REMOVE OR MOVE THIS LINE.
+require_once '/LocalSettings.Extensions.php';
 
 ##############################################################################
 # End of generated LocalSettings.php
 ##############################################################################
 
-# Add configuration values below which should be set after extensions are loaded
+# Add MediaWiki or extension configuration values here that should be set after
+# bundled extensions are loaded.

--- a/build/wikibase/README.md
+++ b/build/wikibase/README.md
@@ -174,14 +174,16 @@ Hooking into the internal filesystem can extend the functionality of this image.
 | `/var/www/html/images`          | MediaWiki image and media upload directory                                                                     |
 | `/var/www/html/skins`           | MediaWiki skins directory                                                                                      |
 | `/var/www/html/extensions`      | MediaWiki extensions directory                                                                                 |
-| `/var/www/html/LocalSettings.d` | MediaWiki LocalSettings configuration directory, sourced in alphabetical order at the end of LocalSettings.php |
+| `/var/www/html/LocalSettings.d` | Bundled extension configuration directory, loaded in alphabetical order by the image-managed extension loader |
 | `/templates/`                   | Directory containing templates                                                                                 |
 
 | File                               | Description                                                                                                                                                                                    |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/default-extra-install.sh`        | Script for automatically creating Elasticsearch indices and creating OAuth consumer for QuickStatements                                                                                        |
 | `/extra-install.sh`                | Optional script for custom functionality to be ran with MediaWiki install (when generating LocalSettings.php)                                                                                  |
-| `/templates/LocalSettings.wbs.php` | Wikibase-specific settings appended to the MediaWiki install generated `LocalSettings.php`. Specifically, this loads the Wikibase repo and client as well as all the other bundled extensions. |
+| `/LocalSettings.MediaWiki.php` | Image-managed core MediaWiki defaults loaded before bundled extensions.                                                                                                                         |
+| `/LocalSettings.Extensions.php` | Image-managed loader for bundled extension configuration in `/var/www/html/LocalSettings.d`.                                                                                                 |
+| `/templates/LocalSettings.wbs.php` | Wikibase-specific settings appended to the MediaWiki install generated `LocalSettings.php`. It provides the stable `require_once` lines for the image-managed MediaWiki and extension loading phases. |
 
 ## Source
 

--- a/docs/adr/0018-anonymous-access-defaults.md
+++ b/docs/adr/0018-anonymous-access-defaults.md
@@ -1,0 +1,56 @@
+# 18) Anonymous access defaults for the Wikibase image {#adr_0018}
+
+Date: 2026-04-20
+
+## Status
+
+accepted
+
+## Context
+
+The Wikibase Suite Docker image ships a `LocalSettings.wbs.php` template which is appended to the generated `LocalSettings.php` on first install. Historically, that template also contained the logic for loading bundled configuration fragments from `build/wikibase/LocalSettings.d`.
+
+That means the user-owned `LocalSettings.php` in the config volume has also contained image-managed bootstrap logic. If an operator edits that loading logic incorrectly, they can break the bundled configuration model of the image.
+
+We want to change the default anonymous access model for the bundled Wikibase image used by Wikibase Suite. The goal is to require a logged-in account for write actions while keeping public read access available.
+
+This decision is driven by two considerations:
+
+- We want the Suite defaults to track Wikibase Cloud security decisions where that is practical for self-hosted defaults. In particular, we want to disable anonymous account creation by default, following the current Wikibase Cloud default as understood by the team for this decision.
+- We want to keep anonymous read access available. In our current stack, anonymous read access is required for WDQS updates, and it is also a sensible default for public-facing Wikibase installations.
+
+We also want this default to be easy to locate, reason about, and override by operators maintaining their own `LocalSettings.php`.
+
+## Decision
+
+The Wikibase image will keep anonymous read access enabled by default, but will disable anonymous write actions and anonymous self-service account creation by default.
+
+The affected defaults will be implemented in:
+
+`build/wikibase/LocalSettings.MediaWiki.php`
+
+That location should contain only the non-default settings needed for this policy:
+
+- `$wgGroupPermissions['*']['edit'] = false;`
+- `$wgGroupPermissions['*']['createpage'] = false;`
+- `$wgGroupPermissions['*']['createtalk'] = false;`
+- `$wgGroupPermissions['*']['writeapi'] = false;`
+- `$wgGroupPermissions['*']['createaccount'] = false;`
+
+We will not add explicit settings for defaults we intend to leave unchanged, such as anonymous read access.
+
+`LocalSettings.wbs.php` will become a thin wrapper that contains stable, image-managed `require_once` lines:
+
+- `require_once '/LocalSettings.MediaWiki.php';`
+- `require_once '/LocalSettings.Extensions.php';`
+
+Between those lines, operators can place MediaWiki settings that must be set before bundled extensions are loaded. After the second line, operators can place settings that should be applied after bundled extensions are loaded.
+
+The general MediaWiki defaults currently defined in `LocalSettings.wbs.php` will also move into `LocalSettings.MediaWiki.php`. The loop over `LocalSettings.d` will move into `LocalSettings.Extensions.php`. This keeps the critical loading logic in image-managed files, while preserving a supported pre-extension configuration section in the user-owned `LocalSettings.php`.
+
+## Consequences
+
+- Anonymous users will still be able to read wiki pages and access public read endpoints.
+- Anonymous users will no longer be able to edit, create pages, create talk pages, use the write API, or create accounts.
+- Browser tests that currently rely on anonymous writing will need to log in before creating or editing content.
+- Operators who want different behavior will be able to override these image defaults in their own MediaWiki configuration.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -26,3 +26,4 @@ Current ADRs include:
 - [15 - security fixes non wmde software](0015-security-fixes-non-wmde-software.md)
 - [16 - updating non wmde software](0016-updating-non-wmde-software.md)
 - [17 - using mediawiki docker image](0017-using-mediawiki-docker-image.md)
+- [18 - anonymous access defaults for the wikibase image](0018-anonymous-access-defaults.md)

--- a/test/helpers/pages/repo-client-login.page.ts
+++ b/test/helpers/pages/repo-client-login.page.ts
@@ -1,0 +1,39 @@
+class RepoClientLoginPage {
+	public get username(): ChainablePromiseElement {
+		return $( '#wpName1' );
+	}
+
+	public get password(): ChainablePromiseElement {
+		return $( '#wpPassword1' );
+	}
+
+	public get loginButton(): ChainablePromiseElement {
+		return $( '#wpLoginAttempt' );
+	}
+
+	public get logoutLink(): ChainablePromiseElement {
+		return $( '#pt-logout' );
+	}
+
+	public async open(): Promise<void> {
+		await browser.url(
+			`${ testEnv.vars.WIKIBASE_CLIENT_URL }/wiki/Special:UserLogin`
+		);
+	}
+
+	public async login( username: string, password: string ): Promise<void> {
+		await this.open();
+		await this.username.setValue( username );
+		await this.password.setValue( password );
+		await this.loginButton.click();
+		await browser.waitUntil(
+			async () => await this.logoutLink.isExisting(),
+			{
+				timeout: 10000,
+				timeoutMsg: 'Expected to be logged in on the client wiki'
+			}
+		);
+	}
+}
+
+export default new RepoClientLoginPage();

--- a/test/specs/elasticsearch/elasticsearch.ts
+++ b/test/specs/elasticsearch/elasticsearch.ts
@@ -1,3 +1,4 @@
+import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import { getTestString } from 'wdio-mediawiki/Util.js';
 import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 import ItemPage from '../../helpers/pages/entity/item.page.js';
@@ -9,6 +10,13 @@ const itemLabel: string = getTestString( 'testItem' );
 
 describe( 'ElasticSearch', function () {
 	let itemId: string;
+
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
 
 	it( 'Should create an item', async function () {
 		itemId = await WikibaseApi.createItem( itemLabel );

--- a/test/specs/repo/anonymous-access.ts
+++ b/test/specs/repo/anonymous-access.ts
@@ -1,0 +1,28 @@
+import page from '../../helpers/pages/page.js';
+
+describe( 'Anonymous access defaults', function () {
+	beforeEach( async function () {
+		await browser.deleteCookies();
+	} );
+
+	it( 'Should allow anonymous users to read wiki pages', async function () {
+		await page.open( '/wiki/Main_Page' );
+
+		const currentUrl = await browser.getUrl();
+		expect( currentUrl ).not.toContain( 'Special:UserLogin' );
+		await expect( $( '#firstHeading' ) ).toBeDisplayed();
+		await expect( $( '#mw-content-text' ) ).toBeDisplayed();
+	} );
+
+	it( 'Should block anonymous users from editing pages', async function () {
+		const pageTitle = `Anonymous_write_smoke_${ Date.now() }`;
+
+		await browser.url( `${ testEnv.vars.WIKIBASE_URL }/wiki/${ pageTitle }?action=edit` );
+
+		await expect( $( '#firstHeading' ) ).toHaveText( 'Permission error' );
+		await expect( $( '#mw-content-text' ) ).toHaveText(
+			expect.stringContaining( 'You do not have permission to create this page' )
+		);
+		await expect( $( '#pt-login-2 a' ) ).toBeDisplayed();
+	} );
+} );

--- a/test/specs/repo/extensions/entityschema.ts
+++ b/test/specs/repo/extensions/entityschema.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'fs/promises';
+import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import page from '../../../helpers/pages/page.js';
 import { utf8 } from '../../../helpers/read-file-encoding.js';
 
@@ -8,6 +9,13 @@ describe( 'EntitySchema', function () {
 
 	beforeEach( async function () {
 		await browser.skipIfExtensionNotPresent( this, 'EntitySchema' );
+	} );
+
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
 	} );
 
 	it( 'Should be able to create an EntitySchema', async function () {

--- a/test/specs/repo/extensions/scribunto.ts
+++ b/test/specs/repo/extensions/scribunto.ts
@@ -1,10 +1,18 @@
 import { readFile } from 'fs/promises';
+import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import { utf8 } from '../../../helpers/read-file-encoding.js';
 
 // Test the installation and function of lua in the Wikibase Docker image
 describe( 'Scribunto', function () {
 	beforeEach( async function () {
 		await browser.skipIfExtensionNotPresent( this, 'Scribunto' );
+	} );
+
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
 	} );
 
 	it( 'Should be able to execute lua module', async function () {

--- a/test/specs/repo/property.ts
+++ b/test/specs/repo/property.ts
@@ -1,3 +1,4 @@
+import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import { parseSemVer } from 'semver-parser';
 import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 import PropertyPage from '../../helpers/pages/entity/property.page.js';
@@ -18,6 +19,13 @@ const referenceText = 'REFERENCE';
 const undoSummaryText = 'UNDO_SUMMARY';
 
 describe( 'Property', function () {
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
+
 	// eslint-disable-next-line mocha/no-setup-in-describe
 	dataTypes.forEach( ( dataType: WikibasePropertyType ) => {
 		// eslint-disable-next-line mocha/no-setup-in-describe
@@ -90,11 +98,7 @@ describe( 'Property', function () {
 
 			it( 'Should display the added properties on the "Recent changes" page', async function () {
 				await browser.waitForJobs();
-				const mediaWikiVersion = await browser.getMediaWikiVersion();
-				if ( parseSemVer( mediaWikiVersion ).minor > 39 ) {
-					await $( '.vector-main-menu-dropdown' ).click();
-				}
-				await $( '=Recent changes' ).click();
+				await page.open( '/wiki/Special:RecentChanges' );
 				await expect( $( `=(${ propertyId })` ) ).toExist();
 				await expect( $( `=(${ stringPropertyId })` ) ).toExist();
 			} );

--- a/test/specs/repo/queryservice.ts
+++ b/test/specs/repo/queryservice.ts
@@ -7,6 +7,13 @@ import SpecialNewItemPage from '../../helpers/pages/special/new-item.page.js';
 import { wikibasePropertyString } from '../../helpers/wikibase-property-types.js';
 
 describe( 'QueryService', function () {
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
+
 	it( 'Should be able to get sparql endpoint', async function () {
 		const result = await browser.makeRequest(
 			`${ testEnv.vars.WDQS_URL }/sparql`

--- a/test/specs/repo/special-new-item.ts
+++ b/test/specs/repo/special-new-item.ts
@@ -1,7 +1,15 @@
+import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import SpecialEntityPage from 'wdio-wikibase/pageobjects/item.page.js';
 import SpecialNewItemPage from '../../helpers/pages/special/new-item.page.js';
 
 describe( 'Special:NewItem', function () {
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
+
 	it( 'Should be able to create a new item', async function () {
 		const label = 'Cool label';
 		const description = 'Cool description';

--- a/test/specs/repo/special-new-property.ts
+++ b/test/specs/repo/special-new-property.ts
@@ -1,3 +1,4 @@
+import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import SpecialListPropertiesPage from '../../helpers/pages/special/list-properties.page.js';
 import SpecialNewPropertyPage from '../../helpers/pages/special/new-property.page.js';
 import {
@@ -14,6 +15,13 @@ const dataTypes = [
 ];
 
 describe( 'Special:NewProperty', function () {
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
+
 	// eslint-disable-next-line mocha/no-setup-in-describe
 	dataTypes.forEach( ( dataType: WikibasePropertyType ) => {
 		// eslint-disable-next-line mocha/no-setup-in-describe

--- a/test/specs/repo_client/extensions/scribunto-item.ts
+++ b/test/specs/repo_client/extensions/scribunto-item.ts
@@ -4,6 +4,7 @@ import LoginPage from 'wdio-mediawiki/LoginPage.js';
 import { getTestString } from 'wdio-mediawiki/Util.js';
 import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 import ItemPage from '../../../helpers/pages/entity/item.page.js';
+import RepoClientLoginPage from '../../../helpers/pages/repo-client-login.page.js';
 import { utf8 } from '../../../helpers/read-file-encoding.js';
 import ExternalChange from '../../../types/external-change.js';
 
@@ -13,6 +14,13 @@ describe( 'Scribunto Item', function () {
 	let itemId: string;
 	const propertyValue = 'PropertyExampleStringValue';
 	const luaPageTitle = 'RepoClientLuaTest';
+
+	before( async function () {
+		await RepoClientLoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
 
 	beforeEach( async function () {
 		await browser.skipIfExtensionNotPresent( this, 'Scribunto' );

--- a/test/specs/repo_client/item.ts
+++ b/test/specs/repo_client/item.ts
@@ -4,6 +4,7 @@ import { getTestString } from 'wdio-mediawiki/Util.js';
 import WikibaseApi from 'wdio-wikibase/wikibase.api.js';
 import ItemPage from '../../helpers/pages/entity/item.page.js';
 import page from '../../helpers/pages/page.js';
+import RepoClientLoginPage from '../../helpers/pages/repo-client-login.page.js';
 import SpecialNewItemPage from '../../helpers/pages/special/new-item.page.js';
 import ExternalChange from '../../types/external-change.js';
 
@@ -14,6 +15,17 @@ describe( 'Item', function () {
 	let propertyId: string = null;
 	const propertyValue = 'PropertyExampleStringValue';
 	const pageTitle = 'Test';
+
+	before( async function () {
+		await LoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+		await RepoClientLoginPage.login(
+			testEnv.vars.MW_ADMIN_NAME,
+			testEnv.vars.MW_ADMIN_PASS
+		);
+	} );
 
 	beforeEach( async function () {
 		await browser.waitForJobs();


### PR DESCRIPTION
In parity with Wikibase Cloud defaults, this updates the Wikibase image defaults so anonymous users keep read access, but can no longer:

- edit pages
- create pages
- create talk pages
- use the write API
- create accounts

Notes:

- Our test suite relied heavily on anonymous write access, so part of this changeset is updates to test suites that now require a logged in user. Fortunately, most of the required changes were able to be carried over from the now rejected Temporary Accounts work that had introduced a similar requirement on our tests. 
- I have also moved the image-managed `LocalSettings` loading into dedicated files so the generated `LocalSettings.php` keeps stable DO NOT REMOVE `require_once` lines while still leaving a supported place for user-defined settings before and after bundled extensions load. This ensures the new defaults are attributes of the image, and come with the upgrade vs the user needing to replace their generated `LocalSettings.php`.

A more comprehensive description of this change and related decision is in the included ADR: [docs/adr/0018-anonymous-access-defaults.md](https://github.com/wmde/wikibase-release-pipeline/blob/22c55bb01b732f2e23e86013d7c54aa338748ddc/docs/adr/0018-anonymous-access-defaults.md)