### PR TITLE
chore(wikibase): prepare 7.0.1 patch release

### DIFF
--- a/build/wikibase/CHANGELOG.md
+++ b/build/wikibase/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.0.1 (2026-04-23)
+
+- Fixes a `7.0.0` regression in the opt-in metadata callback that caused Wikibase startup to fail for instances with `METADATA_CALLBACK=true`.
+
 # 7.0.0 (2026-04-20)
 
 Updates MediaWiki and bundled extensions within the 1.45 release line and adds several new default capabilities to the Wikibase image.

--- a/build/wikibase/package.json
+++ b/build/wikibase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wikibase",
-	"version": "7.0.0",
+	"version": "7.0.1",
 	"nx": {
 		"targets": {
 			"lint": {},


### PR DESCRIPTION
- bump the Wikibase image version from `7.0.0` to `7.0.1`
- add a `7.0.1` Wikibase changelog entry describing the metadata callback fix

The callback fix itself has already been merged to `main`, but the Wikibase image release metadata still needs a patch release follow-up so we can publish a new image version for that fix.

This prepares the Wikibase image release artifacts and release notes for the `7.0.1` patch release.

Verified this branch contains only the version bump and changelog update on top of current `main`.
