### PR TITLE
fix: WDQS updater restart loop

### DIFF
--- a/build/wdqs/README.md
+++ b/build/wdqs/README.md
@@ -92,30 +92,11 @@ Hooking into the internal filesystem can extend the functionality of this image.
 | `/wdqs/RWStore.properties`   | Properties for the service                                                                     |
 | `/templates/mwservices.json` | Template for MediaWiki services (populated and placed into `/wdqs/mwservices.json` at runtime) |
 
-## Known issues
+## Empty-store updater initialization
 
-### Updater keeps restarting
+Before starting, `/runUpdate.sh` checks whether WDQS contains any entities. When WDQS is empty, it initializes the updater checkpoint from the beginning of the UTC day containing the oldest available RecentChanges entry in the configured Wikibase entity namespaces. This allows a freshly installed or previously affected instance to leave a restart loop and import all entities still represented in RecentChanges. If there are no retained RecentChanges entries, it initializes the checkpoint at the beginning of the current UTC day.
 
-In some situations the WDQS Updater enters a restart loop, e.g., when restarted without containing any entities. When you restart a freshly installed instance, you will encounter this issue.
-
-A workaround is to start the updater once with manual `--init` `--start` parameters. This forces it to sync data from MediaWiki for the current day.
-
-In the full Wikibase Suite configuration, or another Docker Compose setup with a `wdqs-updater` service, use the commands below.
-
-```sh
-# Stop the stock updater
-docker compose stop wdqs-updater
-
-# Start an updater with force sync settings
-docker compose run --rm wdqs-updater /wdqs/runUpdate.sh -h http://\$WDQS_HOST:\$WDQS_PORT -- --wikibaseUrl \$WIKIBASE_SCHEME://\$WIKIBASE_HOST --conceptUri \$WIKIBASE_CONCEPT_URI --entityNamespaces \$WDQS_ENTITY_NAMESPACES --init --start $(date +%Y%m%d000000)
-
-# As soon as you see "Sleeping for 10 secs" in the logs, press CTRL-C to stop it again
-
-# Start the stock updater again
-docker compose start wdqs-updater
-```
-
-As soon as the updater has synced the first entity from MediaWiki, the issue should disappear.
+The initialization is guarded: if WDQS contains an entity, or if either service check fails or returns an unexpected response, the updater starts normally without changing its checkpoint. Entities no longer represented in RecentChanges require a full reload as described in [Upgrading](#upgrading).
 
 ## Source
 

--- a/build/wdqs/runUpdate.sh
+++ b/build/wdqs/runUpdate.sh
@@ -1,15 +1,105 @@
 #!/usr/bin/env bash
 # This file is provided by the wikibase/wdqs docker image.
 
-set +u
-if [ -z "$WIKIBASE_CONCEPT_URI" ]; then
-  echo "WIKIBASE_CONCEPT_URI is required but isn't set.";
-  exit 1;
-fi
 set -u
 
-cd /wdqs || exit
+readonly MEDIAWIKI_API_PATH="/w/api.php"
+readonly WDQS_SPARQL_PATH="/bigdata/namespace/wdq/sparql"
 
-/wait-for-it.sh "$WIKIBASE_HOST:80" -t 300 -- \
-/wait-for-it.sh "$WDQS_HOST:$WDQS_PORT" -t 300 -- \
-./runUpdate.sh -h http://"$WDQS_HOST":"$WDQS_PORT" -- --wikibaseUrl "$WIKIBASE_SCHEME"://"$WIKIBASE_HOST" --conceptUri "$WIKIBASE_CONCEPT_URI" --entityNamespaces "$WDQS_ENTITY_NAMESPACES"
+wdqs_is_empty() {
+  local response
+
+  if ! response=$(curl --silent --show-error --fail --get \
+    --header "Accept: application/sparql-results+json" \
+    --data-urlencode "query=ASK { ?entity <http://schema.org/version> ?version }" \
+    "http://${WDQS_HOST}:${WDQS_PORT}${WDQS_SPARQL_PATH}"); then
+    echo "Could not determine whether WDQS contains entities; skipping automatic updater initialization." >&2
+    return 2
+  fi
+
+  if grep --extended-regexp --quiet '"boolean"[[:space:]]*:[[:space:]]*false' <<< "$response"; then
+    return 0
+  fi
+
+  if grep --extended-regexp --quiet '"boolean"[[:space:]]*:[[:space:]]*true' <<< "$response"; then
+    return 1
+  fi
+
+  echo "WDQS returned an unexpected response to the entity check; skipping automatic updater initialization." >&2
+  return 2
+}
+
+wikibase_update_start() {
+  local entity_namespaces
+  local response
+  local timestamp
+
+  entity_namespaces=${WDQS_ENTITY_NAMESPACES//,/|}
+  entity_namespaces=${entity_namespaces//[[:space:]]/}
+  if [[ -z "$entity_namespaces" ]]; then
+    echo "WDQS_ENTITY_NAMESPACES is empty; skipping automatic updater initialization." >&2
+    return 2
+  fi
+
+  if ! response=$(curl --silent --show-error --fail --get \
+    --data-urlencode "action=query" \
+    --data-urlencode "list=recentchanges" \
+    --data-urlencode "rcdir=newer" \
+    --data-urlencode "rclimit=1" \
+    --data-urlencode "rcnamespace=${entity_namespaces}" \
+    --data-urlencode "rcprop=timestamp" \
+    --data-urlencode "format=json" \
+    --data-urlencode "formatversion=2" \
+    "${WIKIBASE_SCHEME}://${WIKIBASE_HOST}${MEDIAWIKI_API_PATH}"); then
+    echo "Could not read Wikibase RecentChanges; skipping automatic updater initialization." >&2
+    return 2
+  fi
+
+  if grep --extended-regexp --quiet '"recentchanges"[[:space:]]*:[[:space:]]*\[[[:space:]]*\]' <<< "$response"; then
+    date --utc +%Y%m%d000000
+    return 0
+  fi
+
+  timestamp=$(grep --only-matching --extended-regexp '"timestamp"[[:space:]]*:[[:space:]]*"[^"]+"' <<< "$response" | \
+    sed --expression 's/.*"timestamp"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/' | \
+    head --lines 1)
+  if [[ ! "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    echo "Wikibase returned an unexpected response to the RecentChanges query; skipping automatic updater initialization." >&2
+    return 2
+  fi
+
+  timestamp=${timestamp%%T*}
+  printf '%s000000\n' "${timestamp//-/}"
+}
+
+main() {
+  local -a initialization_args=()
+  local update_start
+
+  set +u
+  if [[ -z "$WIKIBASE_CONCEPT_URI" ]]; then
+    echo "WIKIBASE_CONCEPT_URI is required but isn't set."
+    exit 1
+  fi
+  set -u
+
+  cd /wdqs || exit
+
+  /wait-for-it.sh "$WIKIBASE_HOST:80" -t 300 -- \
+  /wait-for-it.sh "$WDQS_HOST:$WDQS_PORT" -t 300
+
+  if wdqs_is_empty && update_start=$(wikibase_update_start); then
+    initialization_args=(--init --start "$update_start")
+    echo "WDQS contains no entities; initializing the updater from ${update_start}."
+  fi
+
+  exec ./runUpdate.sh -h "http://${WDQS_HOST}:${WDQS_PORT}" -- \
+    --wikibaseUrl "${WIKIBASE_SCHEME}://${WIKIBASE_HOST}" \
+    --conceptUri "$WIKIBASE_CONCEPT_URI" \
+    --entityNamespaces "$WDQS_ENTITY_NAMESPACES" \
+    "${initialization_args[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/deploy/docs/troubleshooting.md
+++ b/deploy/docs/troubleshooting.md
@@ -18,7 +18,7 @@ If the problem was caused by incorrect `.env` values, fix the values and then fo
 
 ## Query service updater keeps restarting
 
-If the `wdqs-updater` service keeps restarting, check the query service logs:
+If using Wikibase Suite 7.0.0 or before and the `wdqs-updater` service keeps restarting, check the query service logs:
 
 ```sh
 docker compose logs wdqs-updater
@@ -26,7 +26,7 @@ docker compose logs wdqs-updater
 
 This can happen on a fresh or empty instance if the updater is restarted before query service has synced any entity data. The updater can enter a restart loop and needs a manual `--init --start` run before the regular updater can continue.
 
-Follow the recovery procedure in the WDQS image README: [Updater keeps restarting](../../build/wdqs/README.md#updater-keeps-restarting).
+Follow the recovery procedure in the WDQS image README for the latest affected WDQS image version: [Updater keeps restarting](https://github.com/wmde/wikibase-release-pipeline/blob/wdqs%402.1.0/build/wdqs/README.md#updater-keeps-restarting).
 
 Once the updater has synced the first entity from Wikibase, normal restarts should not trigger this same failure mode.
 


### PR DESCRIPTION
Phabricator: [T354266](https://phabricator.wikimedia.org/T354266)

Fixes the WDQS updater restart loop which occurs when the query service contains no entities after an initial restart of the service.

Before launching the upstream updater, the image now checks whether WDQS contains any entities. If WDQS is empty, it queries Wikibase for the oldest available RecentChanges entry in the configured entity namespaces and starts the updater with `--init --start` at the beginning of that UTC day.

If no relevant RecentChanges entries are available, it initializes from the beginning of the current UTC day.

This recovers fresh and previously affected installations and imports everything still represented in RecentChanges. It does not rebuild entities whose changes have already been purged; those require a full RDF dump and reload.

**NOTES:** 

- The PHP Composer 8.2 relied upon for the Wikibase image build was deprecated and removed by the foundation, so was updated to allow Wikibase to build again.
- The queryservice "Should show results from a page in allowlist.txt" test, which calls WikiData directly, was consistently failing due to `query.wikidata.org` rate-limiting on Github CI IPs. That test case has been amended to just its actual scope, confirm the request is allowed, vs also confirming results come back which works around the rate limit error.