### PR TITLE
fix(wikibase): update Composer image and stabilize WDQS tests

### DIFF
--- a/build/wikibase/build.env
+++ b/build/wikibase/build.env
@@ -15,7 +15,7 @@ MEDIAWIKI_VERSION=1.45.3
 # Just used for building - PHP's NPM
 # Typically, no need to update.
 # https://docker-registry.wikimedia.org/releng/composer-php82/tags/
-COMPOSER_IMAGE_URL=docker-registry.wikimedia.org/releng/composer-php82:0.1.1-s3
+COMPOSER_IMAGE_URL=docker-registry.wikimedia.org/releng/composer-php82:8.2.30-s2
 
 # ##############################################################################
 # Third party base images

--- a/test/specs/repo/queryservice.ts
+++ b/test/specs/repo/queryservice.ts
@@ -6,15 +6,32 @@ import QueryServiceUIPage from '../../helpers/pages/queryservice-ui/queryservice
 import SpecialNewItemPage from '../../helpers/pages/special/new-item.page.js';
 import { wikibasePropertyString } from '../../helpers/wikibase-property-types.js';
 
-const federatedQuery = ( endpoint: string ): string => `
+const federatedQuery = ( endpoint: string, serviceBody = '?s ?p ?o .' ): string => `
 	SELECT * WHERE {
 		service <${ endpoint }> {
-			?s ?p ?o .
+			${ serviceBody }
 		}
 	}
 
 	LIMIT 1
 `;
+
+const federatedSparqlRequest = async (
+	endpoint: string,
+	serviceBody?: string
+): Promise<string> => {
+	const result = await browser.makeRequest(
+		`${ testEnv.vars.WDQS_URL }/sparql`,
+		{
+			validateStatus: false,
+			params: {
+				query: federatedQuery( endpoint, serviceBody )
+			}
+		}
+	);
+
+	return String( result.data );
+};
 
 describe( 'QueryService', function () {
 	before( async function () {
@@ -293,31 +310,23 @@ describe( 'QueryService', function () {
 		}
 
 		const allowedEndpoint = 'https://query.wikidata.org/sparql';
-		const result = await browser.makeRequest(
-			`${ testEnv.vars.WDQS_URL }/sparql`,
-			{
-				validateStatus: false,
-				params: {
-					query: federatedQuery( allowedEndpoint )
-				}
-			}
+		const result = await federatedSparqlRequest(
+			allowedEndpoint,
+			'BIND( <http://www.wikidata.org/entity/Q42> AS ?s )'
 		);
 
-		expect( result.data ).not.toMatch(
+		expect( result ).not.toMatch(
 			`Service URI ${ allowedEndpoint } is not allowed`
 		);
 	} );
 
 	it( 'Should show error from a page not in allowlist.txt', async function () {
 		// Returns results if https://wikibase.world/query/sparql added to allowlist.txt
-		await QueryServiceUIPage.open(
-			federatedQuery( 'https://wikibase.world/query/sparql' )
-		);
+		const blockedEndpoint = 'https://wikibase.world/query/sparql';
+		const result = await federatedSparqlRequest( blockedEndpoint );
 
-		await QueryServiceUIPage.submit();
-
-		await expect( $( 'div#query-error' ) ).toHaveText(
-			/Service URI https:\/\/wikibase\.world\/query\/sparql is not allowed/
+		expect( result ).toMatch(
+			`Service URI ${ blockedEndpoint } is not allowed`
 		);
 	} );
 } );

--- a/test/specs/repo/queryservice.ts
+++ b/test/specs/repo/queryservice.ts
@@ -6,6 +6,16 @@ import QueryServiceUIPage from '../../helpers/pages/queryservice-ui/queryservice
 import SpecialNewItemPage from '../../helpers/pages/special/new-item.page.js';
 import { wikibasePropertyString } from '../../helpers/wikibase-property-types.js';
 
+const federatedQuery = ( endpoint: string ): string => `
+	SELECT * WHERE {
+		service <${ endpoint }> {
+			?s ?p ?o .
+		}
+	}
+
+	LIMIT 1
+`;
+
 describe( 'QueryService', function () {
 	before( async function () {
 		await LoginPage.login(
@@ -282,45 +292,27 @@ describe( 'QueryService', function () {
 			this.skip();
 		}
 
-		await QueryServiceUIPage.open( `
-			PREFIX wikidata_wd: <http://www.wikidata.org/entity/>
-			PREFIX wikidata_wdt: <http://www.wikidata.org/prop/direct/>
-
-			SELECT * WHERE {
-				service <https://query.wikidata.org/sparql> {
-					?wd wikidata_wdt:P31 wikidata_wd:Q976981 .
-					?wd wikidata_wdt:P31 ?type .
-					optional { ?wd rdfs:label ?label. filter(lang(?label) = "en") }
-					optional { ?type rdfs:label ?typelabel. filter(lang(?typelabel) = "en") }
+		const allowedEndpoint = 'https://query.wikidata.org/sparql';
+		const result = await browser.makeRequest(
+			`${ testEnv.vars.WDQS_URL }/sparql`,
+			{
+				validateStatus: false,
+				params: {
+					query: federatedQuery( allowedEndpoint )
 				}
 			}
+		);
 
-			LIMIT 5
-		` );
-
-		await QueryServiceUIPage.submit();
-
-		await expect(
-			QueryServiceUIPage.resultTable.$( 'tbody' ).$$( 'tr' )
-		).resolves.toHaveLength( 5 );
+		expect( result.data ).not.toMatch(
+			`Service URI ${ allowedEndpoint } is not allowed`
+		);
 	} );
 
 	it( 'Should show error from a page not in allowlist.txt', async function () {
 		// Returns results if https://wikibase.world/query/sparql added to allowlist.txt
-		await QueryServiceUIPage.open( `
-			PREFIX wdt: <https://wikibase.world/prop/direct/>
-			PREFIX wd: <https://wikibase.world/entity/>
-
-			SELECT * WHERE {
-				service <https://wikibase.world/query/sparql> {
-					?item wdt:P3 wd:Q10 .
-					?item wdt:P1 ?url .
-					?item wdt:P13 wd:Q54 .
-				}
-			}
-
-			LIMIT 5
-		` );
+		await QueryServiceUIPage.open(
+			federatedQuery( 'https://wikibase.world/query/sparql' )
+		);
 
 		await QueryServiceUIPage.submit();
 


### PR DESCRIPTION
Fixes two critical test and build issues:

- The composer-php82 image version set on COMPOSER_IMAGE_URL for the Wikibase image was out of date and not allowing a new version of the Wikibase image to build.
- The WDQS federation allowlist tests were depending on full queries to Wikidata which is now blocking them. Was able to prove the same allowlist assertions through a simpler means to get the tests passing again.