### PR TITLE
fix(wdqs-frontend): use locked GUI dependencies

### DIFF
--- a/build/wdqs-frontend/CHANGELOG.md
+++ b/build/wdqs-frontend/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Loads query examples from the local Wikibase `Project:SPARQL/examples` page instead of Wikidata, migrating the previous Wikidata configuration when present.
 - Removes the hardcoded Wikidata tools and Query Builder navbar links.
 - Adds an image-owned health check for the frontend service.
+- Uses the locked WDQS Query GUI dependency set so the query execution icon renders correctly.
 
 ## 2.1.0 (2026-02-16)
 

--- a/build/wdqs-frontend/Dockerfile
+++ b/build/wdqs-frontend/Dockerfile
@@ -19,11 +19,10 @@ RUN patch -Np1 </tmp/remove-wikidata-tools.patch && \
 # don't install chromium, it is not used
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-# TODO: what if we use the package lock? #reprobuilds
-# we need dev dependencies to run 'npm run build'
-RUN sed -i "/npm: '--production --no-package-lock'/c\npm: '--no-package-lock'" Gruntfile.js && \
-    npm install && \
-    npm run build
+# Install the upstream's locked dependency set, including development dependencies
+# needed by Grunt, then skip its auto_install task to retain that dependency set.
+RUN npm ci && \
+    npx grunt clean only_build
 
 # ###########################################################################
 # hadolint ignore=DL3006


### PR DESCRIPTION
## Summary

Uses the WDQS Query GUI lockfile during the frontend image build and skips Grunt's dependency-reinstall task. The normal build cleanup remains in place.

## Root Cause

The prior build ran `npm install --no-package-lock` from Grunt after the initial install. That allowed the `@wikimedia/codex` dependency range to resolve to a release missing the primary-progressive button icon color rule, leaving the query execute icon blue on a blue button.

## Validation

- `./nx build wdqs-frontend` on Apple Silicon (native ARM image)
- Confirmed the built CSS contains the white primary-progressive icon selector
- `./lint.sh build/wdqs-frontend`
- `git diff --check`