### PR TITLE
chore(deploy): refine upgrade instructions

### DIFF
--- a/deploy/docs/advanced-configuration.md
+++ b/deploy/docs/advanced-configuration.md
@@ -13,7 +13,9 @@ The presence of `config/LocalSettings.php` controls whether WBS starts from exis
 
 This is why changing `.env` and restarting is not a supported way to reconfigure an existing setup. With the exception of `METADATA_CALLBACK`, `.env` values are first-start inputs that were already written into `LocalSettings.php`, the database volume, or other generated state.
 
-If you need to reset, follow [Resetting an instance](./resetting.md). For a major version upgrade, follow the [major upgrade procedure](./updating.md#major-upgrades). Always keep a backup of your old `LocalSettings.php`, and copy local customizations into the file created during reset rather than restoring the old file wholesale.
+If you need to change first-start setup values, follow [Resetting an instance](./resetting.md). During a reset, keep a backup of your old `LocalSettings.php` and copy local customizations into the newly generated file rather than restoring the old file wholesale.
+
+For a major version upgrade, preserve the existing configuration and follow the [major upgrade procedure](./updating.md#major-upgrades).
 
 ## `config/wikibase-php.ini`
 

--- a/deploy/docs/backup-and-restore.md
+++ b/deploy/docs/backup-and-restore.md
@@ -11,9 +11,11 @@ Besides [your configuration](./advanced-configuration.md), your data is what mak
 
 ## Back up your data
 
-Run these commands from the `wikibase-release-pipeline/deploy` directory. To back up your data, shut down the instance and dump the contents of all Docker volumes into `.tar.gz` files.
+Run these commands from the `wikibase-release-pipeline` repository root. They create a `backup` directory beside the repository, shut down the instance, and dump the contents of all Docker volumes into `.tar.gz` files there.
 
 ```sh
+mkdir -p ../backup
+cd deploy
 docker compose down
 
 for v in \
@@ -24,27 +26,30 @@ for v in \
     wbs-deploy_quickstatements-data \
     wbs-deploy_traefik-letsencrypt-data \
     ; do
-  docker run --rm --volume $v:/backup debian:12-slim tar cz backup > $v.tar.gz
+  docker run --rm --volume $v:/backup debian:12-slim tar cz backup > ../../backup/$v.tar.gz
 done
 ```
 
 ## Back up your configuration
 
-To back up local configuration changes, copy the `config` directory:
+To back up local configuration and environment values, copy the `config` directory and `.env` file into the same backup directory:
 
 ```sh
-cp -r ./config ./config-$(date +%Y%m%d%H%M%S)
+mkdir -p ../../backup/config
+cp -a ./config/. ../../backup/config/
+cp -a ./.env ../../backup/.env
 ```
 
-Keep this backup as a reference when resetting or upgrading. It may contain passwords and other secrets, so store it securely. Do not restore old generated configuration files wholesale after reset; manually re-apply your local changes into the new files created during reset.
+Keep this backup as a reference when resetting or upgrading. The `.env` file and configuration may contain plaintext passwords and other secrets, so store the backup directory securely. Do not restore old generated configuration files wholesale after reset; manually re-apply your local changes into the new files created during reset.
 
 ## Restore from a backup
 
-Run these commands from the `wikibase-release-pipeline/deploy` directory. To restore the volume backups, ensure your instance has been shut down by running `docker compose down` and populate the Docker volumes with data from your `.tar.gz` files.
+Run these commands from the `wikibase-release-pipeline` repository root. To restore the volume backups, ensure your instance has been shut down by running `docker compose down` and populate the Docker volumes with data from the sibling `backup` directory. Only restore these backups when recovering from a failed upgrade or reset.
 
 Warning: the restore commands remove the existing Docker volumes before restoring the backup files.
 
 ```sh
+cd deploy
 docker compose down
 
 for v in \
@@ -57,6 +62,6 @@ for v in \
     ; do
   docker volume rm $v 2> /dev/null
   docker volume create $v
-  docker run -i --rm --volume $v:/backup debian:12-slim tar xz < $v.tar.gz
+  docker run -i --rm --volume $v:/backup debian:12-slim tar xz < ../../backup/$v.tar.gz
 done
 ```

--- a/deploy/docs/resetting.md
+++ b/deploy/docs/resetting.md
@@ -36,16 +36,6 @@ Make any needed changes to `.env` before starting the stack again. If you are re
 > [!WARNING]
 > If you are preserving existing data, do not change `DB_NAME`, `DB_USER`, or `DB_PASS` during reset unless you also know how to migrate the matching MariaDB credentials manually. The restored database volume keeps the old database credentials.
 
-If you are resetting as part of a major version upgrade, switch to the new WBS version and pull the updated images before the next start:
-
-```sh
-git remote update
-git checkout deploy@3.0.3
-docker compose pull
-```
-
-Replace `deploy@3.0.3` with the version you are upgrading to. See [Major upgrades](./updating.md#major-upgrades) for version-specific notes.
-
 ## 4. Start once to run setup again
 
 Start the stack:

--- a/deploy/docs/updating.md
+++ b/deploy/docs/updating.md
@@ -42,7 +42,7 @@ Major version upgrades are performed by updating the WBS major version. This is 
 > [!NOTE]  
 > WBS only supports updating from one major version to the next version in sequence. In order to upgrade from 1.x.x to 3.x.x, you must first upgrade from 1.x.x to 2.x.x and then to 3.x.x.
 
-Major upgrades use the data-preserving reset procedure in [Resetting an instance](./resetting.md). Read the version-specific notes below before starting that procedure, then follow the reset procedure and use the target WBS version tag when you reach its "Update setup values" step.
+Before performing a major upgrade, follow [Backup and restore](./backup-and-restore.md) to back up your data and Docker volumes as a precaution in case the upgrade process fails. Read the version-specific notes below before continuing.
 
 > 💡 If you made changes to `docker-compose.yml`, merge them as you see fit.
 
@@ -51,7 +51,7 @@ Look for any new required values in `.env.example` that you may need to add to y
 > [!NOTE]  
 > With the exception of `METADATA_CALLBACK`, do not change existing `.env` values during an upgrade. They are setup values, and changing them while preserving existing data can break your instance. `METADATA_CALLBACK` may be changed after initial setup and takes effect after restarting the services.
 
-Before the final start in the reset procedure, apply any relevant version-specific notes below and update any user-defined extensions installed in `config/extensions`.
+Before starting the upgraded services, apply any relevant version-specific notes below and update any user-defined extensions installed in `config/extensions`.
 
 ### Version-specific notes
 


### PR DESCRIPTION
## Summary

- clarify that major upgrades preserve existing data and require backups as a precaution rather than a reset-and-restore cycle
- store volume archives, configuration, and environment values in a backup directory beside the repository
- make the documented restore paths match the new backup location

## Impact

The 7.x upgrade documentation now provides a safer, clearer backup workflow without implying that users must restore their data during every major upgrade.

## Validation

- git diff --check