### PR TITLE
chore: align legacy channel inputs

### DIFF
--- a/build/quickstatements/Dockerfile
+++ b/build/quickstatements/Dockerfile
@@ -12,7 +12,7 @@ RUN \
     git -C /tmp/quickstatements checkout ${QUICKSTATEMENTS_COMMIT} && \
     git -C /tmp/quickstatements submodule update --init --recursive && \
     \
-    git clone https://bitbucket.org/magnusmanske/magnustools.git /tmp/magnustools && \
+    git clone https://codeberg.org/magnusmanske/magnustools.git /tmp/magnustools && \
     git -C /tmp/magnustools checkout ${MAGNUSTOOLS_COMMIT}
 
 WORKDIR /tmp/quickstatements

--- a/build/quickstatements/build.env
+++ b/build/quickstatements/build.env
@@ -5,7 +5,7 @@ QUICKSTATEMENTS_VERSION=2
 # Updated automatically by ../builder.sh update_hashes
 # https://github.com/magnusmanske/quickstatements/commits/master
 QUICKSTATEMENTS_COMMIT=c4b2c6b086b319aa32dcdd7a323edf188faaa66d
-# https://bitbucket.org/magnusmanske/magnustools/commits/branch/master
+# https://codeberg.org/magnusmanske/magnustools/commits/branch/master
 MAGNUSTOOLS_COMMIT=5b8cea412000072a2c8753023c11472a4ac11ef5
 
 # ##############################################################################

--- a/build/wikibase/build.env
+++ b/build/wikibase/build.env
@@ -5,7 +5,7 @@
 # Update only patch versions for security releases.
 # Choose latest version for major releases.
 # https://releases.wikimedia.org/mediawiki/
-MEDIAWIKI_VERSION=1.43.3
+MEDIAWIKI_VERSION=1.43.9
 
 # ##############################################################################
 # PHP Composer
@@ -13,7 +13,7 @@ MEDIAWIKI_VERSION=1.43.3
 # Just used for building - PHP's NPM
 # Typically, no need to update.
 # https://docker-registry.wikimedia.org/releng/composer-php82/tags/
-COMPOSER_IMAGE_URL=docker-registry.wikimedia.org/releng/composer-php82:0.1.1-s3
+COMPOSER_IMAGE_URL=docker-registry.wikimedia.org/releng/composer-php82:8.2.30-s2
 
 # ##############################################################################
 # Third party base images
@@ -42,25 +42,25 @@ DEBIAN_IMAGE_URL=debian:bookworm-slim
 # Shouldn't require much of a review.
 #
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Wikibase/+/refs/heads/REL1_43
-WIKIBASE_COMMIT=32244a786f5e56cbfd0309dd4d1b61198fa5436c
+WIKIBASE_COMMIT=5f5120105e6bac0b5870ff3dc75ef5f9236b16cc
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Babel/+/refs/heads/REL1_43
-BABEL_COMMIT=ee41786730bda6a5e93f30d00b97cc874f5d59b2
+BABEL_COMMIT=fcb96b5c2bc9aa721370898b07cd7d74c451e7e0
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/cldr/+/refs/heads/REL1_43
-CLDR_COMMIT=cf6c9c70150cec6c1193f6f50dc54b72dc6e0f40
+CLDR_COMMIT=4a8e09346d06d62ff1d2407076e1f0692ce75395
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/CirrusSearch/+/refs/heads/REL1_43
-CIRRUSSEARCH_COMMIT=465d1035ebea07dd55813d8271948da0aab9453a
+CIRRUSSEARCH_COMMIT=4019b7afa8de4269ea930f59bdf9a70025bb4ac8
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Elastica/+/refs/heads/REL1_43
-ELASTICA_COMMIT=bf94e780485bba5ced4bed95d181fe8e897c8316
+ELASTICA_COMMIT=4feb817e2559d246c4cebfd6855e6713e5677066
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/EntitySchema/+/refs/heads/REL1_43
-ENTITYSCHEMA_COMMIT=24d399bb450cf17c58c6118873a098ba8914c42d
+ENTITYSCHEMA_COMMIT=4df3e345de17939535606f161e2a343c41d3c9d4
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/OAuth/+/refs/heads/REL1_43
-OAUTH_COMMIT=a61dad655a61d6e07d6c9031451e080e393b3a76
+OAUTH_COMMIT=270a08f2df0020ac56e737f096683ca3a888932e
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/UniversalLanguageSelector/+/refs/heads/REL1_43
-UNIVERSALLANGUAGESELECTOR_COMMIT=a72fda31fc31f0a26818813529679df55cf16aac
+UNIVERSALLANGUAGESELECTOR_COMMIT=c58aa7262997df7abdd6eff733595789c1750977
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseCirrusSearch/+/refs/heads/REL1_43
-WIKIBASECIRRUSSEARCH_COMMIT=68b2f61b6eb31a7f94fa1fc6bda4ecfd1f878bd1
+WIKIBASECIRRUSSEARCH_COMMIT=52bb4cb184a7a950bcb0f2fa79f48cfbf0b8b4ee
 # https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseManifest/+/refs/heads/REL1_43
-WIKIBASEMANIFEST_COMMIT=1ac23bdc52a27c94a6fdeeba4d005fece13e0fa9
+WIKIBASEMANIFEST_COMMIT=7d8d51a6f1cd11e62f42f1fa6beb6f7ba12c6666
 
 # ##############################################################################
 # Community maintained extensions

--- a/lint.sh
+++ b/lint.sh
@@ -25,6 +25,7 @@ usage() {
 }
 
 # Error handler to capture errors
+# shellcheck disable=SC2329 # shellcheck does not see the usage in the trap
 error_handler() {
   # shellcheck disable=SC2317
   exit_code=1


### PR DESCRIPTION
Updates the Wikibase 4.x image to MediaWiki 1.43.9 and current `REL1_43` extension commits.

This maintenance release is for Wikibase 4Research and is generally available to remaining WBS 4.x / Wikibase 4.x image users.

Only the Wikibase image will be released. Deploy and the other component images are unchanged.
