### PR TITLE
docs(wikibase): record 4.1.2 release

### DIFF
--- a/build/wikibase/CHANGELOG.md
+++ b/build/wikibase/CHANGELOG.md
@@ -61,6 +61,13 @@ Analysis revealed breaking changes expected for a MediaWiki major-version upgrad
 - ⚠️  move callback to wikibase image
 - ⚠️  bump mediawiki to 1.44.0
 
+## 4.1.2 (2026-07-22)
+
+
+### 🩹 Fixes
+
+- Update MediaWiki to 1.43.9 and refresh WMF-maintained extensions on REL1_43
+
 ## 4.1.1 (2025-07-17)
 
 


### PR DESCRIPTION
Adds the Wikibase 4.1.2 maintenance release to the main changelog.

This release updates MediaWiki to 1.43.9 and refreshes WMF-maintained `REL1_43` extensions for Wikibase 4Research and remaining WBS/Wikibase 4.x image users.
